### PR TITLE
BACKLOG-1274: Allow the user to select the version of Jahia 

### DIFF
--- a/src/main/resources/jnt_serverSettingsAboutJahia/html/serverSettingsAboutJahia.settingsBootstrap3GoogleMaterialStyle.jsp
+++ b/src/main/resources/jnt_serverSettingsAboutJahia/html/serverSettingsAboutJahia.settingsBootstrap3GoogleMaterialStyle.jsp
@@ -15,7 +15,7 @@
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>
 
 <div class="page-header">
-    <h2>
+    <h2 style="user-select: text">
         <%= Jahia.getFullProductVersion() %>
         <c:if test="${ licensePackage.customTermsAndConditions eq 'true' }">
             / <fmt:message key="serverSettings.aboutJahia.LicenceInfo.customTermsAndConditionsNotice" />


### PR DESCRIPTION

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-1274

## Description
Allow the user to select the version of Jahia in the header by overriding the default header style

