### PR TITLE
BACKLOG-12950: Remove deprecated route to portlet management

### DIFF
--- a/src/javascript/serverSettings/systemComponents/registerRoutes.js
+++ b/src/javascript/serverSettings/systemComponents/registerRoutes.js
@@ -9,13 +9,4 @@ export const registerRoutes = function () {
         label: 'serverSettings:systemComponents.label',
         isSelectable: false
     });
-
-    registry.add('adminRoute', 'managePortlets', {
-        targets: ['administration-server-systemComponents:50'],
-        requiredPermission: 'adminPortlets',
-        icon: null,
-        label: 'serverSettings:systemComponents.portlets',
-        isSelectable: true,
-        iframeUrl: window.contextJsParameters.contextPath + '/cms/adminframe/default/en/settings.managePortlets.html?redirect=false'
-    });
 };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12950

## Description

Remove deprecated route to portlet management


