### PR TITLE
SEC-108: Temporarily setting a resolution for path-to-regexp to v1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "*/**/trim-newlines": "3.0.1",
     "*/**/ejs": "3.1.7",
     "*/**/scss-tokenizer": "0.4.3",
-    "**/glob-parent": "^5.1.2"
+    "**/glob-parent": "^5.1.2",
+    "*/**/path-to-regexp": "1.9.0"
   },
   "dependencies": {
     "@jahia/moonstone": "^2.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3900,10 +3900,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+path-to-regexp@1.9.0, path-to-regexp@^1.7.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
   dependencies:
     isarray "0.0.1"
 


### PR DESCRIPTION
https://jira.jahia.org/browse/SEC-108

Note: This is not a long-term solution, but instead a quick fix to allow for merging of PRs on the serverSettings repo (as the alternative would be to update the security threshold on the static analysis action).

Sample of failing PR: https://github.com/Jahia/serverSettings/pull/131 

The long term solution is to implement https://jira.jahia.org/browse/TECH-1980

