### PR TITLE
fix(security): Prevent path traversal attack

### DIFF
--- a/src/main/java/org/jahia/modules/serversettings/portlets/PreparedPortletsController.java
+++ b/src/main/java/org/jahia/modules/serversettings/portlets/PreparedPortletsController.java
@@ -44,6 +44,7 @@
 package org.jahia.modules.serversettings.portlets;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.ServletRequestUtils;
@@ -66,6 +67,8 @@ public class PreparedPortletsController implements Controller {
         String warName = null;
         try {
             fileName = ServletRequestUtils.getRequiredStringParameter(request, "file");
+            // prevent path traversal
+            fileName = FilenameUtils.getName(fileName);
             warName = ServletRequestUtils.getStringParameter(request, "war", fileName);
             war = new File(System.getProperty("java.io.tmpdir"), fileName);
         } catch (ServletRequestBindingException e) {


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/4005.
### Description
Prevent [path traversal attack](https://owasp.org/www-community/attacks/Path_Traversal) in `PreparedPortletsController`.
Note that this file is no longer present on https://github.com/Jahia/serverSettings/tree/master since [TECH-1027](https://jira.jahia.org/browse/TECH-1027).

NB: the build will pass once https://github.com/Jahia/serverSettings/pull/163 is merged and this branch gets rebased.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
