### PR TITLE
fix(security): bump path-to-regexp (CVE-2024-45296)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "*/**/trim-newlines": "3.0.1",
     "*/**/ejs": "3.1.7",
     "*/**/scss-tokenizer": "0.4.3",
-    "**/glob-parent": "^5.1.2"
+    "**/glob-parent": "^5.1.2",
+    "*/**/path-to-regexp": "1.9.0"
   },
   "dependencies": {
     "@jahia/moonstone": "^2.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3636,10 +3636,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+path-to-regexp@1.9.0, path-to-regexp@^1.7.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
   dependencies:
     isarray "0.0.1"
 


### PR DESCRIPTION
### Description
Backport of https://github.com/Jahia/serverSettings/pull/132 onto the 9.7.x branch (used by the upcoming Jahia 8.1.9.0 that will be updated, see https://github.com/Jahia/jahia-pack-private/blob/JAHIA-8-1-9-X-BRANCH/core-modules/pom.xml#L287).
This prevents [CVE-2024-45296](https://github.com/advisories/GHSA-9wv6-86v2-598j).

Currently, the PRs towards the https://github.com/Jahia/serverSettings/tree/9_7_x branch fail (see [this run](https://github.com/Jahia/serverSettings/actions/runs/16288720941/job/45993348053?pr=162)):
```
Found vulnerable advisory paths:
GHSA-9wv6-86v2-598j|react-router-dom>react-router>path-to-regexp
GHSA-9wv6-86v2-598j|react-router>path-to-regexp
Failed security audit due to high vulnerabilities.
Vulnerable advisories are:
https://github.com/advisories/GHSA-9wv6-86v2-598j
Exiting...
Error: Process completed with exit code 1.
```

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
