### PR TITLE
chore: bump minimal Jahia version from 8.2.0.0 to 8.2.4.0

### DIFF
--- a/.chachalog/sExzH7MD.md
+++ b/.chachalog/sExzH7MD.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+serverSettings: minor
+---
+
+Bump minimal Jahia version from 8.2.0.0 to 8.2.4.0 (#202)

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.2.0.0</version>
+        <version>8.2.4.0-SNAPSHOT</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
### Description
https://github.com/Jahia/serverSettings/pull/198 requires `@jahia/moonstone` in version >= 2.19.0, which is shipped by JContent 3.7, itself shipped in Jahia 8.2.4.0.

See https://jahia.slack.com/archives/C0A2AJ0D16F/p1780560890284369 for additional context.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
