### PR TITLE
ci: disabled nightly-rl workflow

### DIFF
--- a/.github/workflows/nightly-rl.yml.md
+++ b/.github/workflows/nightly-rl.yml.md
@@ -1,4 +1,4 @@
-This workflow has been disabled.
+This workflow has been removed.
 
 It was testing the latest snapshot of this module against the latest Jahia release,
 which is not a relevant scenario for serverSettings: this module is exclusively
@@ -6,29 +6,4 @@ bundled within Jahia releases and is never distributed or installed independentl
 As a result, there will never be a case where a newer version of this module needs
 to be installed on an older release of Jahia.
 
-Only the nightly workflow testing againts Jahia snapshot is meaningful for this module.
-
-
-```yaml
-name: Nightly Test run (Jahia Release)
-
-on:
-  workflow_dispatch:
-  schedule:
-    - cron:  '0 3 * * *'
-
-jobs:
- integration-tests-rl:
-   name: Integration Tests (Jahia RL)
-   secrets: inherit
-   uses: Jahia/jahia-modules-action/.github/workflows/reusable-integration-tests.yml@v2
-   with:
-     module_id: serverSettings
-     module_branch: main
-     jahia_image: jahia/jahia-ee:8
-     provisioning_manifest: provisioning-manifest-snapshot.yml
-     incident_service: serverSettings-JahiaRL
-     testrail_project: ServerSettings Module
-     artifact_prefix: serset-rl
-     timeout_job: 45
-```
+Only the nightly workflow testing against Jahia snapshot is meaningful for this module.

--- a/.github/workflows/nightly-rl.yml.md
+++ b/.github/workflows/nightly-rl.yml.md
@@ -1,3 +1,15 @@
+This workflow has been disabled.
+
+It was testing the latest snapshot of this module against the latest Jahia release,
+which is not a relevant scenario for serverSettings: this module is exclusively
+bundled within Jahia releases and is never distributed or installed independently.
+As a result, there will never be a case where a newer version of this module needs
+to be installed on an older release of Jahia.
+
+Only the nightly workflow testing againts Jahia snapshot is meaningful for this module.
+
+
+```yaml
 name: Nightly Test run (Jahia Release)
 
 on:
@@ -19,3 +31,4 @@ jobs:
      testrail_project: ServerSettings Module
      artifact_prefix: serset-rl
      timeout_job: 45
+```

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -66,7 +66,7 @@ jobs:
     with:
       module_id: serverSettings
       module_branch: ${{ github.ref }}
-      jahia_image: ghcr.io/jahia/jahia-ee-dev:8.2-SNAPSHOT
+      jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
       provisioning_manifest: provisioning-manifest-build.yml
       testrail_project: ServerSettings Module
       should_skip_testrail: true

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -75,7 +75,7 @@ jobs:
     with:
       module_id: serverSettings
       module_branch: main
-      jahia_image: ghcr.io/jahia/jahia-ee-dev:8.2-SNAPSHOT
+      jahia_image: ghcr.io/jahia/jahia-ee-dev:8-SNAPSHOT
       provisioning_manifest: provisioning-manifest-build.yml
       incident_service: serverSettings-JahiaSN
       testrail_project: ServerSettings Module


### PR DESCRIPTION
Disabled workflow and add a brief documentation for whoever might wonder in the future why this workflow is not present.

Also modified the SNAPSHOT image, there's no point in testing specifically against 8.2-SNAPSHOT (instead of just 8-SNAPSHOT)