### PR TITLE
feat: removal of default JCR content related to the forge

### DIFF
--- a/.chachalog/N3f-u0QB.md
+++ b/.chachalog/N3f-u0QB.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+serverSettings: minor
+---
+
+Replace store (also known as forge) UI and JCR settings (serverSettings, serverSettings-ee, jahia-private, module-manager) by OSGI configuration files (module-manager)

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
 
     <properties>
         <jahia-depends>default,siteSettings</jahia-depends>
-        <export-package>org.jahia.modules.serversettings.forge</export-package>
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <jahia-module-signature>MCwCFELZgVKpaJ/XnvB4ZgfsBniniIZlAhQO121+heyrVAs+8POcF4te3cSg9Q==</jahia-module-signature>

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -4,7 +4,6 @@
         <administrationAccess jcr:primaryType="jnt:permission" />
         <licenseUpdate jcr:primaryType="jnt:permission" />
         <searchSettings jcr:primaryType="jnt:permission" />
-        <privateAppStore jcr:primaryType="jnt:permission" />
         <adminServerRoles jcr:primaryType="jnt:permission" />
         <adminVirtualSites jcr:primaryType="jnt:permission" />
         <adminEmailSettings jcr:primaryType="jnt:permission" />

--- a/src/main/import/settings.xml
+++ b/src/main/import/settings.xml
@@ -1,10 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <content xmlns:j="http://www.jahia.org/jahia/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
-    <forgesSettings jcr:primaryType="jnt:forgesServerSettings">
-        <j:acl j:inherit="false" jcr:primaryType="jnt:acl"/>
-        <httpstorejahiacomensitesprivate j:password=""
-                                         j:url="https://store.jahia.com/en/sites/private-app-store"
-                                         j:user=""
-                                         jcr:primaryType="jnt:forgeServerSettings"/>
-    </forgesSettings>
 </content>


### PR DESCRIPTION
### Description

Removal of default JCR content related to the forge and package export related to forge code, now in module-manager.
Modifications done in the scope of the issue **[Bounty - Replace the "App stores" screen under admin => server => "App stores" by cfg files](https://github.com/Jahia/jahia-private/issues/4898)**.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
