### PR TITLE
build: Add `mise` configuration

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "18.18"
+yarn = "1"


### PR DESCRIPTION
### Description
When we switch between repositories, we have to manage different versions of Yarn, and it's confusing to know which repo uses which.

This PR adds a [mise](https://mise.jdx.dev/) configuration so anyone with mise installed automatically gets the right Node and Yarn versions the project expects.

- I added the same Node versions used in `pom.xml`. I don't include the last digit to keep some flexibility about the version used locally.
- I set Yarn to version "1" because the real issue occurs when we switch to a repository configured with version "4". 

### Usage
- Install [mise](https://mise.jdx.dev/getting-started.html) (if you don't have it): `brew install mise`, and make sure it's activated in your shell (e.g. `eval "$(mise activate zsh)"` in `~/.zshrc`).
- From the repo run `mise install`