### PR TITLE
test: fix test by adding loginAndStoreSession

### DIFF
--- a/tests/cypress/e2e/passwordPolicy.cy.ts
+++ b/tests/cypress/e2e/passwordPolicy.cy.ts
@@ -121,8 +121,9 @@ describe('Password Policy Tests', () => {
         policyPage.checkRule(RULES.PREVENT_PASSWORD_CHANGE).save()
         cy.logout()
 
-        // Log in as server-admin test user and attempt to change password via profile
-        cy.login(TEST_USER, TEST_USER_PASSWORD)
+        // Log in as server-admin test user and attempt to change password via profile.
+        // Use a validated, isolated session to avoid interference with other tests.
+        cy.loginAndStoreSession(TEST_USER, TEST_USER_PASSWORD)
         cy.visit('/jahia/profile')
         const profileIframe = 'iframe[src*="me.html"]'
         cy.get(profileIframe, { timeout: 60000 }).should('exist')


### PR DESCRIPTION
### Description
Fix test `should prevent non-root users from changing their passwords when rule is enabled` by adding loginAndStoreSession.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
