### PR TITLE
test: Add tests on users

### DIFF
--- a/tests/cypress/e2e/page-object/ManageUsersPage.ts
+++ b/tests/cypress/e2e/page-object/ManageUsersPage.ts
@@ -1,0 +1,156 @@
+import { BasePage } from '@jahia/cypress'
+
+export interface UserFormData {
+    username?: string
+    firstName?: string
+    lastName?: string
+    email?: string
+    organization?: string
+    password?: string
+    passwordConfirm?: string
+    preferredLanguage?: string
+}
+
+export class ManageUsersPage extends BasePage {
+    static readonly IFRAME_SELECTOR = 'iframe[src*="manageUsers"]'
+
+    static visit(): ManageUsersPage {
+        cy.visit('/jahia/administration/manageUsers')
+        const page = new ManageUsersPage()
+        cy.frameLoaded(ManageUsersPage.IFRAME_SELECTOR)
+        return page
+    }
+
+    iframe() {
+        return cy.iframe(ManageUsersPage.IFRAME_SELECTOR)
+    }
+
+    /* Open the "Create new user" form. */
+    openCreateForm(): ManageUsersPage {
+        this.iframe().find('button[onclick*="addUser"]').click()
+        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
+        cy.wait(2000)
+        return this
+    }
+
+    /* Fill the create/edit user form. Only provided fields are typed. */
+    fillForm(data: UserFormData): ManageUsersPage {
+        if (data.username !== undefined) {
+            this.iframe().find('#username').clear().type(data.username)
+        }
+        if (data.firstName !== undefined) {
+            this.iframe().find('#firstName').clear().type(data.firstName)
+        }
+        if (data.lastName !== undefined) {
+            this.iframe().find('#lastName').clear().type(data.lastName)
+        }
+        if (data.email !== undefined) {
+            this.iframe().find('#email').clear().type(data.email)
+        }
+        if (data.organization !== undefined) {
+            this.iframe().find('#organization').clear().type(data.organization)
+        }
+        if (data.password !== undefined) {
+            this.iframe().find('#password').clear().type(data.password)
+        }
+        if (data.passwordConfirm !== undefined) {
+            this.iframe().find('#passwordConfirm').clear().type(data.passwordConfirm)
+        }
+        if (data.preferredLanguage !== undefined) {
+            this.iframe().find('#preferredLanguage').select(data.preferredLanguage)
+        }
+        return this
+    }
+
+    /* Submit the create-user form. */
+    submitCreate(): ManageUsersPage {
+        this.iframe().find('button[type="submit"][name="_eventId_add"]').click()
+        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
+        cy.wait(2000)
+        return this
+    }
+
+    /* Submit the edit-user form. */
+    submitUpdate(): ManageUsersPage {
+        this.iframe().find('button[type="submit"][name="_eventId_update"]').click()
+        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
+        cy.wait(2000)
+        return this
+    }
+
+    verifyErrorMessage(message: string): ManageUsersPage {
+        this.iframe().find('.alert-danger').should('contain', message)
+        return this
+    }
+
+    verifyUserListed(username: string): ManageUsersPage {
+        this.iframe().contains('a', username).should('exist')
+        return this
+    }
+
+    verifyUserNotListed(username: string): ManageUsersPage {
+        this.iframe().contains('a', username).should('not.exist')
+        return this
+    }
+
+    /* Type a term in the search box and submit the search. */
+    search(term: string): ManageUsersPage {
+        this.iframe().find('input[name="searchString"]').clear().type(term)
+        this.iframe().find('button[name="_eventId_search"]').click()
+        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
+        cy.wait(2000)
+        return this
+    }
+
+    /* Open an existing user for editing by clicking its link. */
+    openUser(username: string): ManageUsersPage {
+        this.iframe().contains('a', username).click()
+        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
+        cy.wait(2000)
+        return this
+    }
+
+    /* Click the "Export or Remove" fab button for the given user. */
+    openExportOrRemove(username: string): ManageUsersPage {
+        this.iframe().find(`a[title="Export or Remove"][onclick*="/${username}'"]`).click()
+        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
+        cy.wait(2000)
+        return this
+    }
+
+    /* On the Export/Remove page, verify all input fields are disabled. */
+    verifyAllFieldsDisabled(): ManageUsersPage {
+        this.iframe()
+            .find('input.form-control')
+            .each(($el) => {
+                cy.wrap($el).should('be.disabled')
+            })
+        return this
+    }
+
+    /* Trigger the delete confirmation modal and confirm the deletion. */
+    deleteFromRemovePage(): ManageUsersPage {
+        this.iframe().find('button[data-target="#confirmDeleteModal"]').click()
+        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
+        cy.wait(1000)
+        this.iframe().find('#confirmDeleteModal').should('be.visible')
+        this.iframe()
+            .find('#confirmDeleteModal')
+            .find('button[name="_eventId_delete"], button.btn-danger, a.btn-danger')
+            .last()
+            .click()
+        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
+        cy.wait(2000)
+        return this
+    }
+
+    /* On the Export/Remove page, verify the Export link points to the export archive. */
+    verifyExportLink(username: string): ManageUsersPage {
+        this.iframe()
+            .find('a.pull-right')
+            .filter(`[href*="/cms/export/"][href*="/${username}.zip"]`)
+            .should('have.attr', 'href')
+            .and('include', `/${username}.zip`)
+        return this
+    }
+}

--- a/tests/cypress/e2e/page-object/ManageUsersPage.ts
+++ b/tests/cypress/e2e/page-object/ManageUsersPage.ts
@@ -25,12 +25,29 @@ export class ManageUsersPage extends BasePage {
         return cy.iframe(ManageUsersPage.IFRAME_SELECTOR)
     }
 
+    /*
+     * Poll the iframe's live document until `selector` is present, instead of a
+     * fixed delay. This reliably waits for the (re)loaded page after an action
+     * that navigates the iframe. `selector` may be a grouped CSS selector
+     * (e.g. "a, b") to wait for any one of several possible landing states.
+     */
+    private waitForIframeElement(selector: string, timeout = 10000): ManageUsersPage {
+        cy.waitUntil(
+            () =>
+                cy.get(ManageUsersPage.IFRAME_SELECTOR).then(($iframe) => $iframe.contents().find(selector).length > 0),
+            {
+                errorMsg: `Timed out waiting for "${selector}" to appear in the iframe`,
+                timeout,
+                interval: 200,
+            },
+        )
+        return this
+    }
+
     /* Open the "Create new user" form. */
     openCreateForm(): ManageUsersPage {
         this.iframe().find('button[onclick*="addUser"]').click()
-        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
-        cy.wait(2000)
-        return this
+        return this.waitForIframeElement('#username')
     }
 
     /* Fill the create/edit user form. Only provided fields are typed. */
@@ -65,17 +82,15 @@ export class ManageUsersPage extends BasePage {
     /* Submit the create-user form. */
     submitCreate(): ManageUsersPage {
         this.iframe().find('button[type="submit"][name="_eventId_add"]').click()
-        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
-        cy.wait(2000)
-        return this
+        // Success returns to the user list ("Create new user" button); a validation
+        // error re-renders the form with an alert. Wait for either outcome.
+        return this.waitForIframeElement('button[onclick*="addUser"], .alert-danger')
     }
 
     /* Submit the edit-user form. */
     submitUpdate(): ManageUsersPage {
         this.iframe().find('button[type="submit"][name="_eventId_update"]').click()
-        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
-        cy.wait(2000)
-        return this
+        return this.waitForIframeElement('button[onclick*="addUser"], .alert-danger')
     }
 
     verifyErrorMessage(message: string): ManageUsersPage {
@@ -97,25 +112,22 @@ export class ManageUsersPage extends BasePage {
     search(term: string): ManageUsersPage {
         this.iframe().find('input[name="searchString"]').clear().type(term)
         this.iframe().find('button[name="_eventId_search"]').click()
-        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
-        cy.wait(2000)
-        return this
+        // Wait for the results list to be rendered again.
+        return this.waitForIframeElement('button[onclick*="addUser"]')
     }
 
     /* Open an existing user for editing by clicking its link. */
     openUser(username: string): ManageUsersPage {
         this.iframe().contains('a', username).click()
-        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
-        cy.wait(2000)
-        return this
+        // Wait for the edit form to load.
+        return this.waitForIframeElement('#organization')
     }
 
     /* Click the "Export or Remove" fab button for the given user. */
     openExportOrRemove(username: string): ManageUsersPage {
         this.iframe().find(`a[title="Export or Remove"][onclick*="/${username}'"]`).click()
-        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
-        cy.wait(2000)
-        return this
+        // Wait for the Export/Remove page to load.
+        return this.waitForIframeElement('button[data-target="#confirmDeleteModal"]')
     }
 
     /* On the Export/Remove page, verify all input fields are disabled. */
@@ -131,17 +143,15 @@ export class ManageUsersPage extends BasePage {
     /* Trigger the delete confirmation modal and confirm the deletion. */
     deleteFromRemovePage(): ManageUsersPage {
         this.iframe().find('button[data-target="#confirmDeleteModal"]').click()
-        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
-        cy.wait(1000)
+        // The confirmation modal is toggled by JS; assert it is visible (retries).
         this.iframe().find('#confirmDeleteModal').should('be.visible')
         this.iframe()
             .find('#confirmDeleteModal')
             .find('button[name="_eventId_delete"], button.btn-danger, a.btn-danger')
             .last()
             .click()
-        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
-        cy.wait(2000)
-        return this
+        // Deletion returns to the user list.
+        return this.waitForIframeElement('button[onclick*="addUser"]')
     }
 
     /* On the Export/Remove page, verify the Export link points to the export archive. */

--- a/tests/cypress/e2e/users.cy.ts
+++ b/tests/cypress/e2e/users.cy.ts
@@ -1,0 +1,161 @@
+import { createUser, deleteUser } from '@jahia/cypress'
+import { ManageUsersPage } from './page-object/ManageUsersPage'
+
+describe('Manage Users - Create / Search / Edit / Delete Tests', () => {
+    const PASSWORD = 'TestPass12&'
+    const createdUsers: string[] = []
+    const EXISTING_USER = 'existingTestUser'
+    const SEARCH_USER = 'searchTestUser'
+    const EDIT_USER = 'editTestUser'
+    const DELETE_USER = 'deleteTestUser'
+    const REMOVE_USER = 'removeTestUser'
+    const EXPORT_USER = 'exportTestUser'
+
+    before(() => {
+        cy.login()
+        createUser(EXISTING_USER, PASSWORD)
+        createUser(SEARCH_USER, PASSWORD)
+        createUser(EDIT_USER, PASSWORD)
+        createUser(DELETE_USER, PASSWORD)
+        createUser(REMOVE_USER, PASSWORD)
+        createUser(EXPORT_USER, PASSWORD)
+    })
+
+    beforeEach(() => {
+        cy.login()
+    })
+
+    after(() => {
+        cy.login()
+        ;[EXISTING_USER, SEARCH_USER, EDIT_USER, DELETE_USER, REMOVE_USER, EXPORT_USER, ...createdUsers].forEach(
+            (user) => {
+                deleteUser(user)
+            },
+        )
+    })
+
+    it('should create a user with all profile fields filled', () => {
+        const username = 'fullUser01'
+        createdUsers.push(username)
+
+        const page = ManageUsersPage.visit()
+        page.openCreateForm()
+            .fillForm({
+                username,
+                firstName: 'John',
+                lastName: 'Doe',
+                email: 'john.doe@jahia.com',
+                organization: 'Jahia',
+                password: PASSWORD,
+                passwordConfirm: PASSWORD,
+            })
+            .submitCreate()
+            .verifyUserListed(username)
+    })
+
+    it('should create a user with allowed special characters in the username', () => {
+        const username = 'user_-.@{}01'
+        createdUsers.push(username)
+
+        const page = ManageUsersPage.visit()
+        page.openCreateForm()
+            .fillForm({
+                username,
+                password: PASSWORD,
+                passwordConfirm: PASSWORD,
+            })
+            .submitCreate()
+            .verifyUserListed(username)
+    })
+
+    it('should reject a username with not allowed special characters', () => {
+        const username = 'invalid#user!'
+
+        const page = ManageUsersPage.visit()
+        page.openCreateForm()
+            .fillForm({
+                username,
+                password: PASSWORD,
+                passwordConfirm: PASSWORD,
+            })
+            .submitCreate()
+            .verifyErrorMessage("only characters (a..z, A..Z, 0..9, _, -, ., @, '{', '}') are valid for the user name.")
+    })
+
+    it('should reject when password confirmation does not match', () => {
+        const username = 'mismatchUser01'
+
+        const page = ManageUsersPage.visit()
+        page.openCreateForm()
+            .fillForm({
+                username,
+                password: PASSWORD,
+                passwordConfirm: 'DifferentPass12&',
+            })
+            .submitCreate()
+            .verifyErrorMessage('Password confirmation does not match. Please try again.')
+    })
+
+    it('should create a user with preferred language set to French', () => {
+        const username = 'frenchUser01'
+        createdUsers.push(username)
+
+        const page = ManageUsersPage.visit()
+        page.openCreateForm()
+            .fillForm({
+                username,
+                password: PASSWORD,
+                passwordConfirm: PASSWORD,
+                preferredLanguage: 'fr',
+            })
+            .submitCreate()
+            .verifyUserListed(username)
+    })
+
+    it('should reject a username that already exists', () => {
+        const page = ManageUsersPage.visit()
+        page.openCreateForm()
+            .fillForm({
+                username: EXISTING_USER,
+                password: PASSWORD,
+                passwordConfirm: PASSWORD,
+            })
+            .submitCreate()
+            .verifyErrorMessage(`Username '${EXISTING_USER}' already exists`)
+    })
+
+    it('should search for a user and list it', () => {
+        const page = ManageUsersPage.visit()
+        page.search(SEARCH_USER).verifyUserListed(SEARCH_USER)
+    })
+
+    it('should delete a user so it no longer appears in the list', () => {
+        const page = ManageUsersPage.visit()
+        page.openExportOrRemove(DELETE_USER).deleteFromRemovePage()
+
+        ManageUsersPage.visit().search(DELETE_USER).verifyUserNotListed(DELETE_USER)
+    })
+
+    it('should edit a user by adding an organization and updating', () => {
+        const organization = 'Jahia'
+
+        const page = ManageUsersPage.visit()
+        page.openUser(EDIT_USER).fillForm({ organization }).submitUpdate()
+
+        // Reopen the user and verify the organization persisted.
+        ManageUsersPage.visit().openUser(EDIT_USER)
+        page.iframe().find('#organization').should('have.value', organization)
+    })
+
+    it('should open Export or Remove, verify fields are disabled, then delete', () => {
+        const page = ManageUsersPage.visit()
+        page.openExportOrRemove(REMOVE_USER).verifyAllFieldsDisabled().deleteFromRemovePage()
+
+        ManageUsersPage.visit().search(REMOVE_USER).verifyUserNotListed(REMOVE_USER)
+    })
+
+    it('should open Export or Remove, verify fields are disabled, then export', () => {
+        const page = ManageUsersPage.visit()
+        page.openExportOrRemove(EXPORT_USER).verifyAllFieldsDisabled().verifyExportLink(EXPORT_USER)
+    })
+})

--- a/tests/cypress/e2e/users.cy.ts
+++ b/tests/cypress/e2e/users.cy.ts
@@ -129,22 +129,20 @@ describe('Manage Users - Create / Search / Edit / Delete Tests', () => {
         page.search(SEARCH_USER).verifyUserListed(SEARCH_USER)
     })
 
-    it('should delete a user so it no longer appears in the list', () => {
+    it('should delete a user', () => {
         const page = ManageUsersPage.visit()
         page.openExportOrRemove(DELETE_USER).deleteFromRemovePage()
 
         ManageUsersPage.visit().search(DELETE_USER).verifyUserNotListed(DELETE_USER)
     })
 
-    it('should edit a user by adding an organization and updating', () => {
-        const organization = 'Jahia'
-
+    it('should edit a user', () => {
         const page = ManageUsersPage.visit()
-        page.openUser(EDIT_USER).fillForm({ organization }).submitUpdate()
+        page.openUser(EDIT_USER).fillForm({ organization: 'Jahia' }).submitUpdate()
 
         // Reopen the user and verify the organization persisted.
         ManageUsersPage.visit().openUser(EDIT_USER)
-        page.iframe().find('#organization').should('have.value', organization)
+        page.iframe().find('#organization').should('have.value', 'Jahia')
     })
 
     it('should open Export or Remove, verify fields are disabled, then delete', () => {


### PR DESCRIPTION
### Description
Add Cypress tests on users (Create / Search / Edit / Delete Tests) in server settings.
It includes Selenium test `createServerAdminUserTest`

⚠️**Integration tests are failing - fixed in https://github.com/Jahia/serverSettings/pull/223**

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
