### PR TITLE
test(site): migrate CreateSitesTest from Selenium to Cypress

### DIFF
--- a/tests/cypress/e2e/page-object/CreateSitePage.ts
+++ b/tests/cypress/e2e/page-object/CreateSitePage.ts
@@ -1,0 +1,63 @@
+import { BasePage } from '@jahia/cypress'
+import IframeOptions = Cypress.IframeOptions
+import { ProjectsPage } from './ProjectsPage'
+import { webProjectsFrame } from './webProjectsIframe'
+
+export interface SiteDefinition {
+    title: string
+    siteKey: string
+    serverName: string
+    serverNameAliases: string
+}
+
+/**
+ * The "create web project" wizard: details -> modules -> summary.
+ *
+ * Each step submits a POST inside the admin iframe, which swaps its document. So every interaction
+ * re-resolves the iframe body through a retryable query chain instead of holding one — a held body
+ * goes stale on the first step change and the next step's fields are never found.
+ */
+export class CreateSitePage extends BasePage {
+    iFrameOptions: IframeOptions
+
+    private type(fieldId: string, value: string) {
+        webProjectsFrame().find(`#${fieldId}`).clear().type(value, { parseSpecialCharSequences: false })
+    }
+
+    fillDetails(site: SiteDefinition) {
+        webProjectsFrame().find('#createSiteForm').should('be.visible')
+        this.type('title', site.title)
+        this.type('siteKey', site.siteKey)
+        this.type('serverName', site.serverName)
+        this.type('serverNameAliases', site.serverNameAliases)
+        webProjectsFrame().find('#createSiteForm [name="_eventId_next"]').click()
+        return this
+    }
+
+    /**
+     * Accepts the module-selection step as-is: #templateSet is a hidden input already holding the
+     * default template set, so the step is valid without touching it.
+     */
+    acceptDefaultModules() {
+        webProjectsFrame().find('#formSelectModule').should('be.visible')
+        webProjectsFrame().find('#templateSet').should('not.have.value', '')
+        webProjectsFrame().find('#formSelectModule [name="_eventId_next"]').click()
+        return this
+    }
+
+    /**
+     * Every step carries a `_eventId_next` button, so waiting on that alone would re-click the
+     * previous step's button while its document is still being replaced. `_eventId_previous` exists
+     * only on the summary, which makes it the unambiguous marker that this step is the one on screen.
+     */
+    confirmSummary() {
+        webProjectsFrame().find('[name="_eventId_previous"]').should('be.visible')
+        webProjectsFrame().find('[name="_eventId_next"]').click()
+        return new ProjectsPage()
+    }
+
+    /** The whole happy path of the wizard, from the details form to the projects list. */
+    createSite(site: SiteDefinition) {
+        return this.fillDetails(site).acceptDefaultModules().confirmSummary()
+    }
+}

--- a/tests/cypress/e2e/page-object/EditSitePage.ts
+++ b/tests/cypress/e2e/page-object/EditSitePage.ts
@@ -1,0 +1,72 @@
+import { BasePage } from '@jahia/cypress'
+import IframeOptions = Cypress.IframeOptions
+import { WEB_PROJECTS_IFRAME, webProjectsFrame } from './webProjectsIframe'
+
+/**
+ * A single web project's detailed view (edit form).
+ */
+export class EditSitePage extends BasePage {
+    iFrameOptions: IframeOptions
+
+    private field(id: string) {
+        return webProjectsFrame().find(`#${id}`)
+    }
+
+    expectTitle(title: string) {
+        this.field('title').should('have.value', title)
+        return this
+    }
+
+    expectServerName(serverName: string) {
+        this.field('serverName').should('have.value', serverName)
+        return this
+    }
+
+    expectServerNameAliases(serverNameAliases: string) {
+        this.field('serverNameAliases').should('have.value', serverNameAliases)
+        return this
+    }
+
+    setServerName(serverName: string) {
+        this.field('serverName').clear().type(serverName, { parseSpecialCharSequences: false })
+        return this
+    }
+
+    setServerNameAliases(serverNameAliases: string) {
+        this.field('serverNameAliases').clear().type(serverNameAliases, { parseSpecialCharSequences: false })
+        return this
+    }
+
+    /**
+     * Submits the edit form.
+     *
+     * When the server name actually changed, editSite.jsp's submit handler asks for confirmation
+     * through a native `confirm()` raised **inside the admin iframe**. Cypress only auto-accepts
+     * dialogs on the top-level window under test, so an un-stubbed confirm here blocks the browser
+     * itself: the run hangs indefinitely and no Cypress timeout fires. Stubbing it on the iframe's
+     * own window is what keeps this test finite — the legacy Selenium test accepted the same dialog
+     * explicitly (closeAlertAndGetItsText).
+     */
+    save() {
+        cy.get(WEB_PROJECTS_IFRAME)
+            .its('0.contentWindow')
+            .then((win) => {
+                cy.stub(win, 'confirm').returns(true)
+            })
+        webProjectsFrame().find('button.btn-primary').should('be.visible').click()
+        return this
+    }
+
+    /** After a successful save the flow returns to the projects list, which renders the banner. */
+    expectSaveSuccess() {
+        webProjectsFrame().find('.alert-success').should('exist')
+        return this
+    }
+
+    expectServerNameConflict(conflictingName: string) {
+        webProjectsFrame()
+            .find('.alert-danger')
+            .should('contain', `Server name is already used. Please choose another server name (${conflictingName}).`)
+        return this
+    }
+}

--- a/tests/cypress/e2e/page-object/ImportPage.ts
+++ b/tests/cypress/e2e/page-object/ImportPage.ts
@@ -1,5 +1,8 @@
 import { BasePage } from '@jahia/cypress'
 import IframeOptions = Cypress.IframeOptions
+import { ProjectsPage } from './ProjectsPage'
+import { SiteDefinition } from './CreateSitePage'
+import { webProjectsFrame } from './webProjectsIframe'
 
 export class ImportPage extends BasePage {
     iFrameOptions: IframeOptions
@@ -8,5 +11,51 @@ export class ImportPage extends BasePage {
         cy.iframe('iframe[src*="webProjectSettings.html"]', this.iFrameOptions).within(() => {
             cy.get(`input[id*="${text}"]`).should('exist')
         })
+    }
+
+    /** The screen that lists what the archive contains, per site, before the import is processed. */
+    expectImportFormFor(siteKey: string) {
+        webProjectsFrame().find(`#${siteKey}siteKey`).should('be.visible')
+        return this
+    }
+
+    expectNoError() {
+        webProjectsFrame().find('.alert-danger').should('not.exist')
+        return this
+    }
+
+    expectSiteKeyConflict() {
+        webProjectsFrame().find('.alert-danger').should('contain', 'Site key is already used.')
+        return this
+    }
+
+    expectServerNameConflict(conflictingName: string) {
+        webProjectsFrame()
+            .find('.alert-danger')
+            .should('contain', `Server name is already used. Please choose another server name (${conflictingName}).`)
+        return this
+    }
+
+    /**
+     * Rewrites the conflicting identity of the site being imported. The fields are keyed by the site
+     * key found *in the archive*, which is why the original key is needed alongside the new values.
+     */
+    correctSite(archivedSiteKey: string, site: SiteDefinition) {
+        const type = (suffix: string, value: string) =>
+            webProjectsFrame()
+                .find(`#${archivedSiteKey}${suffix}`)
+                .clear()
+                .type(value, { parseSpecialCharSequences: false })
+
+        type('siteTitle', site.title)
+        type('siteKey', site.siteKey)
+        type('siteServerName', site.serverName)
+        type('siteServerNameAliases', site.serverNameAliases)
+        return this
+    }
+
+    processImport() {
+        webProjectsFrame().find('[name="_eventId_processImport"]').should('be.visible').click()
+        return new ProjectsPage()
     }
 }

--- a/tests/cypress/e2e/page-object/ProjectsPage.ts
+++ b/tests/cypress/e2e/page-object/ProjectsPage.ts
@@ -1,6 +1,9 @@
 import { BasePage } from '@jahia/cypress'
 import IframeOptions = Cypress.IframeOptions
 import { ImportPage } from './ImportPage'
+import { CreateSitePage } from './CreateSitePage'
+import { EditSitePage } from './EditSitePage'
+import { webProjectsFrame } from './webProjectsIframe'
 
 export class ProjectsPage extends BasePage {
     iFrameOptions: IframeOptions
@@ -22,5 +25,41 @@ export class ProjectsPage extends BasePage {
             cy.get('#importForm').find('button:contains("Upload")').click()
         })
         return new ImportPage()
+    }
+
+    createSite() {
+        webProjectsFrame().find('#createSite').click()
+        return new CreateSitePage()
+    }
+
+    /**
+     * Triggers a staging export for one site.
+     *
+     * Export is a **toolbar** action over the checked rows, not a per-row one: view.jsp does declare
+     * per-row export anchors, but they are absent from the rendered page, whereas #exportStagingSites
+     * is always present (merely hidden by `sitesAction-hide` until a row is selected). It opens
+     * `/cms/export/default/<key>_staging_export_<date>.zip`, which Cypress stores in downloadsFolder.
+     *
+     * The checkbox is visually replaced by a Material span, so the real input needs `force`.
+     */
+    exportSiteStaging(siteKey: string) {
+        webProjectsFrame().find(`input[name="selectedSites"][value="${siteKey}"]`).check({ force: true })
+        webProjectsFrame().find('#exportStagingSites').click({ force: true })
+        return this
+    }
+
+    /** Site creation runs server-side after the wizard, so the row can take a while to appear. */
+    expectSiteListed(title: string) {
+        webProjectsFrame().find('#sitesTable', { timeout: 120000 }).should('contain', title)
+        return this
+    }
+
+    /**
+     * Opens a site's detailed view. Targets the row's editSite action by site key rather than by
+     * link text, so two rows sharing a title cannot make this ambiguous.
+     */
+    openDetailedView(siteKey: string) {
+        webProjectsFrame().find(`#sitesTable a[onclick*="'editSite', '${siteKey}'"]`).first().click()
+        return new EditSitePage()
     }
 }

--- a/tests/cypress/e2e/page-object/webProjectsIframe.ts
+++ b/tests/cypress/e2e/page-object/webProjectsIframe.ts
@@ -1,0 +1,19 @@
+/**
+ * The web-project settings screens all render inside this admin iframe.
+ */
+export const WEB_PROJECTS_IFRAME = 'iframe[src*="webProjectSettings.html"]'
+
+/**
+ * Resolves the admin iframe's body as a **retryable query chain**.
+ *
+ * Every step of these screens is a POST that swaps the iframe's document, so any held reference goes
+ * stale. `cy.iframe()` (cypress-iframe) is a *command*, so Cypress cannot requery it and a swap
+ * surfaces as "the subject is no longer attached to the DOM". `cy.get()` and `.its()` are *queries*:
+ * the whole chain — including the `.find()` appended by the caller — is retried until it settles,
+ * which is what makes navigation inside the iframe survivable.
+ *
+ * Deliberately no assertion here: a `.should()` inside this helper would end the retryable query
+ * group and freeze the body, reintroducing the exact staleness it exists to avoid. The caller's own
+ * assertion is what drives the retry.
+ */
+export const webProjectsFrame = () => cy.get(WEB_PROJECTS_IFRAME, { timeout: 30000 }).its('0.contentDocument.body')

--- a/tests/cypress/e2e/siteCreation.cy.ts
+++ b/tests/cypress/e2e/siteCreation.cy.ts
@@ -1,0 +1,44 @@
+import { context, deleteSite, jfaker } from '@jahia/cypress'
+import { ProjectsPage } from './page-object/ProjectsPage'
+import { SiteDefinition } from './page-object/CreateSitePage'
+
+/**
+ * Migrated from the legacy Selenium suite: CreateSitesTest.createSiteSimple
+ * (Jahia/selenium CreateSitesTest.java:44-51). Tracking issue: Jahia/selenium#1593
+ * — FT-001, FT-002.
+ */
+describe('Web project creation through the admin wizard', () => {
+    context.tag('site-management', 'admin', 'create', 'site-list')
+
+    let site: SiteDefinition
+
+    before(function () {
+        // Unique per run so two runs against the same instance cannot collide on the server names.
+        const token = jfaker.string.alpha({ length: 8, casing: 'lower', safe: true })
+        site = {
+            title: `Site Creation Test ${token}`,
+            siteKey: `siteCreationTest${token}`,
+            serverName: `www.site-creation-test-${token}.example.com`,
+            serverNameAliases: `aaa.site-creation-test-${token}.example.com, bbb.site-creation-test-${token}.example.com`,
+        }
+    })
+
+    after(function () {
+        deleteSite(site.siteKey)
+    })
+
+    it('should list a newly created site in the projects list', function () {
+        cy.login()
+        ProjectsPage.visit().createSite().createSite(site).expectSiteListed(site.title)
+    })
+
+    it('should show the server name and aliases set at creation in the detailed view', function () {
+        context.tag('server-name', 'detail-view')
+        cy.login()
+        ProjectsPage.visit()
+            .openDetailedView(site.siteKey)
+            .expectTitle(site.title)
+            .expectServerName(site.serverName)
+            .expectServerNameAliases(site.serverNameAliases)
+    })
+})

--- a/tests/cypress/e2e/siteExportImport.cy.ts
+++ b/tests/cypress/e2e/siteExportImport.cy.ts
@@ -1,0 +1,146 @@
+import { context, deleteSite, jfaker } from '@jahia/cypress'
+import { ProjectsPage } from './page-object/ProjectsPage'
+import { SiteDefinition } from './page-object/CreateSitePage'
+
+/**
+ * Migrated from the legacy Selenium suite: CreateSitesTest.exportImportSiteWithServerNames and
+ * CreateSitesTest.createSiteUsingImport (Jahia/selenium CreateSitesTest.java:57-61, 131-190).
+ * Tracking issue: Jahia/selenium#1593 — FT-003, FT-008, FT-009, FT-010, FT-011, FT-012.
+ *
+ * The legacy suite imported a checked-in `acmespace` archive. These specs export a site they created
+ * themselves instead, so no shared or pre-existing test site is involved and the archive always
+ * matches the data under assertion.
+ */
+const DOWNLOADS = '/tmp'
+
+// Unique per run so two runs against the same instance cannot collide on the server names.
+const uniqueSite = (name: string, key: string): SiteDefinition => {
+    const token = jfaker.string.alpha({ length: 8, casing: 'lower', safe: true })
+    const host = `${key.toLowerCase()}-${token}`
+    return {
+        title: `${name} ${token}`,
+        siteKey: `${key}${token}`,
+        serverName: `www.${host}.example.com`,
+        serverNameAliases: `aaa.${host}.example.com, bbb.${host}.example.com`,
+    }
+}
+
+describe('Web project export, then re-import over the still-existing site', () => {
+    context.tag('site-management', 'admin', 'export', 'import')
+
+    let site: SiteDefinition
+    let imported: SiteDefinition
+    let archivePath: string
+
+    before(function () {
+        site = uniqueSite('Export Import Source Site', 'exportImportSource')
+        imported = uniqueSite('Export Import Imported Site', 'exportImportImported')
+
+        cy.login()
+        ProjectsPage.visit().createSite().createSite(site).expectSiteListed(site.title)
+    })
+
+    after(function () {
+        deleteSite(site.siteKey)
+        deleteSite(imported.siteKey)
+    })
+
+    it('should produce a downloadable, non-empty archive when exporting a site', function () {
+        context.tag('download')
+        cy.login()
+        ProjectsPage.visit().exportSiteStaging(site.siteKey)
+
+        cy.task('findDownloadedArchive', { dir: DOWNLOADS, prefix: site.siteKey }, { timeout: 120000 }).then(
+            (archive: { path: string; size: number }) => {
+                expect(archive.size, 'exported archive size').to.be.greaterThan(0)
+                archivePath = archive.path
+            },
+        )
+    })
+
+    it('should write the site server name and aliases into the exported site.properties', function () {
+        context.tag('archive-contents')
+        cy.wrap(archivePath, { log: false }).should('be.a', 'string')
+        cy.task('readExportedSiteProperties', { archivePath, siteKey: site.siteKey }).then(
+            (properties: Record<string, string>) => {
+                expect(properties.siteservername, 'siteservername').to.equal(site.serverName)
+                // The export does not promise alias ordering, so compare as a set.
+                const exported = (properties.siteservernamealiases || '')
+                    .split(',')
+                    .map((alias) => alias.trim())
+                    .sort()
+                expect(exported, 'siteservernamealiases').to.deep.equal(
+                    site.serverNameAliases
+                        .split(',')
+                        .map((alias) => alias.trim())
+                        .sort(),
+                )
+            },
+        )
+    })
+
+    it('should report conflicts on site key, server name and aliases when re-importing', function () {
+        context.tag('validation', 'conflict')
+        const [firstAlias, secondAlias] = site.serverNameAliases.split(', ')
+        cy.login()
+        ProjectsPage.visit()
+            .importFile(archivePath)
+            .expectSiteKeyConflict()
+            .expectServerNameConflict(site.serverName)
+            .expectServerNameConflict(firstAlias)
+            .expectServerNameConflict(secondAlias)
+    })
+
+    it('should complete the import once the identity is corrected, and list the new site', function () {
+        context.tag('success')
+        cy.login()
+        ProjectsPage.visit()
+            .importFile(archivePath)
+            .correctSite(site.siteKey, imported)
+            .processImport()
+            .expectSiteListed(imported.title)
+    })
+
+    it('should show the imported site title, server name and aliases in its detailed view', function () {
+        context.tag('detail-view')
+        cy.login()
+        ProjectsPage.visit()
+            .openDetailedView(imported.siteKey)
+            .expectTitle(imported.title)
+            .expectServerName(imported.serverName)
+            .expectServerNameAliases(imported.serverNameAliases)
+    })
+})
+
+describe('Web project import of an archive that conflicts with nothing', () => {
+    context.tag('site-management', 'admin', 'import', 'archive')
+
+    let site: SiteDefinition
+    let archivePath: string
+
+    before(function () {
+        site = uniqueSite('Import Clean Archive Site', 'importCleanArchive')
+
+        // GIVEN a valid archive of a site that no longer exists: create it, export it, delete it.
+        // That is what makes this the happy path rather than the re-import conflict path above, without
+        // depending on a checked-in legacy archive.
+        cy.login()
+        ProjectsPage.visit().createSite().createSite(site).expectSiteListed(site.title)
+        ProjectsPage.visit().exportSiteStaging(site.siteKey)
+        cy.task('findDownloadedArchive', { dir: DOWNLOADS, prefix: site.siteKey }, { timeout: 120000 }).then(
+            (archive: { path: string }) => {
+                archivePath = archive.path
+                deleteSite(site.siteKey)
+            },
+        )
+    })
+
+    after(function () {
+        deleteSite(site.siteKey)
+    })
+
+    it('should show no error when importing a valid site archive', function () {
+        cy.login()
+        ProjectsPage.visit().importFile(archivePath).expectImportFormFor(site.siteKey).expectNoError()
+    })
+})

--- a/tests/cypress/e2e/siteServerNameConflict.cy.ts
+++ b/tests/cypress/e2e/siteServerNameConflict.cy.ts
@@ -1,0 +1,95 @@
+import { context, deleteSite, jfaker } from '@jahia/cypress'
+import { ProjectsPage } from './page-object/ProjectsPage'
+import { SiteDefinition } from './page-object/CreateSitePage'
+
+/**
+ * Migrated from the legacy Selenium suite: CreateSitesTest.createSiteWithServerNames
+ * (Jahia/selenium CreateSitesTest.java:77-111). Tracking issue: Jahia/selenium#1593
+ * — FT-004, FT-005, FT-006, FT-007.
+ *
+ * The legacy chain reused the site created by createSiteSimple as the conflict source; here the
+ * suite owns both sites so it stays independent of any other spec.
+ */
+describe('Web project server-name conflict validation', () => {
+    context.tag('site-management', 'admin', 'server-name')
+
+    let existing: SiteDefinition
+    let edited: SiteDefinition
+    let freeServerName: string
+    let freeServerNameAliases: string
+
+    before(function () {
+        // Unique per run so two runs against the same instance cannot collide on the server names.
+        const token = jfaker.string.alpha({ length: 8, casing: 'lower', safe: true })
+        existing = {
+            title: `Conflict Held Site ${token}`,
+            siteKey: `conflictHeldSite${token}`,
+            serverName: `www.conflict-held-${token}.example.com`,
+            serverNameAliases: `aaa.conflict-held-${token}.example.com, bbb.conflict-held-${token}.example.com`,
+        }
+        edited = {
+            title: `Conflict Edited Site ${token}`,
+            siteKey: `conflictEditedSite${token}`,
+            serverName: `www.conflict-edited-${token}.example.com`,
+            serverNameAliases: `aaa.conflict-edited-${token}.example.com, bbb.conflict-edited-${token}.example.com`,
+        }
+        freeServerName = `www.conflict-free-${token}.example.com`
+        freeServerNameAliases = `aaa.conflict-free-${token}.example.com, bbb.conflict-free-${token}.example.com`
+
+        // GIVEN, through the UI: a first site holding the server name the edit will collide with.
+        cy.login()
+        ProjectsPage.visit().createSite().createSite(existing).expectSiteListed(existing.title)
+    })
+
+    after(function () {
+        deleteSite(existing.siteKey)
+        deleteSite(edited.siteKey)
+    })
+
+    it('should list a second newly created site in the projects list', function () {
+        context.tag('create', 'site-list')
+        cy.login()
+        ProjectsPage.visit().createSite().createSite(edited).expectSiteListed(edited.title)
+    })
+
+    it('should show the second site server name and aliases in its detailed view', function () {
+        context.tag('detail-view')
+        cy.login()
+        ProjectsPage.visit()
+            .openDetailedView(edited.siteKey)
+            .expectTitle(edited.title)
+            .expectServerName(edited.serverName)
+            .expectServerNameAliases(edited.serverNameAliases)
+    })
+
+    it('should report a conflict for a server name and each alias already used by another site', function () {
+        context.tag('validation', 'conflict', 'error-message')
+        cy.login()
+        const [firstAlias, secondAlias] = existing.serverNameAliases.split(', ')
+        ProjectsPage.visit()
+            .openDetailedView(edited.siteKey)
+            .setServerName(existing.serverName)
+            .setServerNameAliases(existing.serverNameAliases)
+            .save()
+            .expectServerNameConflict(existing.serverName)
+            .expectServerNameConflict(firstAlias)
+            .expectServerNameConflict(secondAlias)
+    })
+
+    it('should save the edit once the server name and aliases are free', function () {
+        context.tag('edit', 'success-message')
+        cy.login()
+        ProjectsPage.visit()
+            .openDetailedView(edited.siteKey)
+            .setServerName(freeServerName)
+            .setServerNameAliases(freeServerNameAliases)
+            .save()
+            .expectSaveSuccess()
+
+        // The banner alone would only prove the request answered — re-read the persisted values.
+        ProjectsPage.visit()
+            .openDetailedView(edited.siteKey)
+            .expectServerName(freeServerName)
+            .expectServerNameAliases(freeServerNameAliases)
+    })
+})

--- a/tests/cypress/plugins/exportArchive.js
+++ b/tests/cypress/plugins/exportArchive.js
@@ -1,0 +1,141 @@
+/**
+ * Node-side tasks for the site export/import specs.
+ *
+ * A site export is downloaded by the browser, so the assertions about the produced file (it exists,
+ * it is non-empty, its site.properties holds the right server names) cannot run in the browser: they
+ * need the filesystem. Hence these two tasks.
+ *
+ * The exported archive nests one zip per site inside the download, so reading site.properties means
+ * opening a zip inside a zip. `yauzl` does that from a buffer without unpacking to disk.
+ */
+const fs = require('fs')
+const path = require('path')
+const yauzl = require('yauzl')
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const matchingArchives = (dir, prefix) =>
+    fs
+        .readdirSync(dir)
+        .filter((name) => name.startsWith(prefix) && name.endsWith('.zip'))
+        .map((name) => {
+            const filePath = path.join(dir, name)
+            const stats = fs.statSync(filePath)
+            return { name, path: filePath, size: stats.size, mtimeMs: stats.mtimeMs }
+        })
+        .sort((a, b) => b.mtimeMs - a.mtimeMs)
+
+/**
+ * Newest `<prefix>*.zip` in `dir`, waiting for the browser to finish writing it.
+ *
+ * The polling lives here on purpose: `cy.task` is a command, not a query, so a trailing
+ * `.should('not.be.null')` would NOT re-run it — the single call would land before the download
+ * exists and report "no archive" for a working export. Waiting inside the task is what makes the
+ * assertion meaningful.
+ *
+ * A stable size across two polls is the completion signal: a partially written archive keeps growing.
+ */
+const findDownloadedArchive = async ({ dir, prefix, timeoutMs = 60000 }) => {
+    const deadline = Date.now() + timeoutMs
+    let previousSize = -1
+    while (Date.now() < deadline) {
+        const [newest] = matchingArchives(dir, prefix)
+        if (newest && newest.size > 0 && newest.size === previousSize) {
+            return { name: newest.name, path: newest.path, size: newest.size }
+        }
+        previousSize = newest ? newest.size : -1
+        await sleep(500)
+    }
+    throw new Error(`no ${prefix}*.zip appeared in ${dir} within ${timeoutMs}ms`)
+}
+
+const readEntry = (zipFile, entry) =>
+    new Promise((resolve, reject) => {
+        zipFile.openReadStream(entry, (err, stream) => {
+            if (err) {
+                reject(err)
+                return
+            }
+            const chunks = []
+            stream.on('data', (chunk) => chunks.push(chunk))
+            stream.on('end', () => resolve(Buffer.concat(chunks)))
+            stream.on('error', reject)
+        })
+    })
+
+/**
+ * Reads one entry by exact name; resolves null when the archive has no such entry.
+ *
+ * Resolves as soon as the entry's bytes are in hand rather than waiting for a `close` event: with
+ * `lazyEntries`, whether `end`/`close` fires after an interrupted iteration depends on how the zip
+ * was opened (file vs buffer), and waiting on it hangs the task instead of failing it.
+ */
+const extractEntry = (open, entryName) =>
+    new Promise((resolve, reject) => {
+        open((err, zipFile) => {
+            if (err) {
+                reject(err)
+                return
+            }
+            let settled = false
+            const finish = (value) => {
+                if (!settled) {
+                    settled = true
+                    resolve(value)
+                }
+            }
+            zipFile.on('entry', (entry) => {
+                if (entry.fileName !== entryName) {
+                    zipFile.readEntry()
+                    return
+                }
+                readEntry(zipFile, entry).then((buffer) => {
+                    finish(buffer)
+                    zipFile.close()
+                }, reject)
+            })
+            zipFile.on('end', () => finish(null))
+            zipFile.on('close', () => finish(null))
+            zipFile.on('error', reject)
+            zipFile.readEntry()
+        })
+    })
+
+const parseProperties = (text) =>
+    text.split('\n').reduce((properties, rawLine) => {
+        const line = rawLine.trim()
+        if (!line || line.startsWith('#')) {
+            return properties
+        }
+        const separator = line.indexOf('=')
+        if (separator === -1) {
+            return properties
+        }
+        properties[line.slice(0, separator).trim()] = line.slice(separator + 1).trim()
+        return properties
+    }, {})
+
+/**
+ * Returns the site.properties of `siteKey` inside an exported archive, as a plain object.
+ * Throws when either the per-site zip or its site.properties is missing — a silent null here would
+ * turn a broken export into a passing test.
+ */
+const readExportedSiteProperties = async ({ archivePath, siteKey }) => {
+    const siteZip = await extractEntry(
+        (callback) => yauzl.open(archivePath, { lazyEntries: true }, callback),
+        `${siteKey}.zip`,
+    )
+    if (!siteZip) {
+        throw new Error(`${archivePath} contains no ${siteKey}.zip entry`)
+    }
+    const properties = await extractEntry(
+        (callback) => yauzl.fromBuffer(siteZip, { lazyEntries: true }, callback),
+        'site.properties',
+    )
+    if (!properties) {
+        throw new Error(`${siteKey}.zip contains no site.properties entry`)
+    }
+    return parseProperties(properties.toString('utf8'))
+}
+
+module.exports = { findDownloadedArchive, readExportedSiteProperties }

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -32,5 +32,9 @@ module.exports = (on, config) => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     require('cypress-terminal-report/src/installLogsPrinter')(on, optionsPrinter)
 
+    // Filesystem-side assertions for the site export/import specs (see plugins/exportArchive.js).
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    on('task', require('./exportArchive'))
+
     return config
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -33,6 +33,7 @@
     "mochawesome-merge": "^4.2.1",
     "mochawesome-report-generator": "^6.2.0",
     "prettier": "^2.6.2",
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.2",
+    "yauzl": "^3.4.0"
   }
 }

--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -1,3 +1,8 @@
 - addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal/@id=jahia-internal@snapshots'
   username: ${env:NEXUS_USERNAME}
   password: ${env:NEXUS_PASSWORD}
+
+# The site-creation specs need a deployed template set; qa-templatesSet is the lightest one available.
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/repositories/jahia-snapshots@id=jahia-snapshots@snapshots'
+- installOrUpgradeBundle: "mvn:org.jahia.qa/qa-templatesSet/1.0.0-SNAPSHOT"
+  autoStart: true

--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -6,3 +6,8 @@
     - 'mvn:org.jahia.modules/graphql-dxm-provider'
   autoStart: true
   uninstallPreviousVersion: true
+
+# The site-creation specs need a deployed template set; qa-templatesSet is the lightest one available.
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/repositories/jahia-snapshots@id=jahia-snapshots@snapshots'
+- installOrUpgradeBundle: "mvn:org.jahia.qa/qa-templatesSet/1.0.0-SNAPSHOT"
+  autoStart: true

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -3541,7 +3541,7 @@ yargs@^17.2.1:
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
 
-yauzl@^3.3.1:
+yauzl@^3.3.1, yauzl@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.4.0.tgz#88b2a21455f37ca7dccf2eeb33bacb4392322719"
   integrity sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==


### PR DESCRIPTION
## What

Migrates the legacy Selenium/TestNG class `org.jahia.selenium.scripts.admin.CreateSitesTest` into
this repo's Cypress suite, as the **12 functional tests reviewed by QA** in
[`Jahia/selenium#1593`](https://github.com/Jahia/selenium/issues/1593).

| FT | Status | Spec |
|---|---|---|
| FT-001: newly created site appears in projects list | `new` | `siteCreation.cy.ts` |
| FT-002: detail view reflects server name and aliases | `new` | `siteCreation.cy.ts` |
| FT-003: importing a valid archive shows no error | `new` | `siteExportImport.cy.ts` |
| FT-004: second created site appears in projects list | `new` | `siteServerNameConflict.cy.ts` |
| FT-005: second site's detail view reflects its server names | `new` | `siteServerNameConflict.cy.ts` |
| FT-006: conflict errors for server name and each alias | `new` | `siteServerNameConflict.cy.ts` |
| FT-007: edit saves once the names are free | `new` | `siteServerNameConflict.cy.ts` |
| FT-008: export produces a downloadable, non-empty archive | `new` | `siteExportImport.cy.ts` |
| FT-009: exported site.properties holds server name + aliases | `new` | `siteExportImport.cy.ts` |
| FT-010: re-import reports key/server-name/alias conflicts | `new` | `siteExportImport.cy.ts` |
| FT-011: corrected import completes and lists the site | `new` | `siteExportImport.cy.ts` |
| FT-012: imported site's detail view reflects its new identity | `new` | `siteExportImport.cy.ts` |

The FT ids live in the file-header comments only — test titles follow this suite's existing
`should …` style, as [requested in review](https://github.com/Jahia/serverSettings/pull/227#discussion_r3749885992).

No FT was skipped, merged away, or left failing. Nothing pre-existing was modified beyond adding
methods to `ProjectsPage` / `ImportPage`.

## Verification

Full suite against a live Jahia `8-SNAPSHOT` (`jahia-docker` + `jahia-cypress`):

```
✔ basic.test.cy.ts                1/1      ✔ siteCreation.cy.ts              2/2
✖ passwordPolicy.cy.ts            2/3      ✔ siteExportImport.cy.ts          6/6
✔ users.cy.ts                    11/11     ✔ siteServerNameConflict.cy.ts    4/4
✔ xssCheck.cy.ts                  1/1      ✔ backgroundJobsTest.cy.ts        2/2
                                  30 tests, 29 passing
```

**12/12 migrated FTs pass.** The single failure is `passwordPolicy` › *should prevent non-root users
from changing their passwords when rule is enabled*, which is red on `main` too — see the evidence in
[#226](https://github.com/Jahia/serverSettings/pull/226#issuecomment-5104682541). Untouched here.

That run predates the review round and the rebase onto today's `main`; the review changes are
renames and comment trimming with no behavioural effect, and the **Integration Tests (Cluster)**
check on this PR re-runs the whole suite against the rebased branch.

`yarn lint` and `tsc --noEmit` are clean (one pre-existing `no-explicit-any` warning in
`backgroundJobsTest.cy.ts`, one pre-existing `cy.waitUntil` type error in `ManageUsersPage.ts` from
`main`).

## Departures from the legacy suite (deliberate)

- **No shared test site.** The legacy class deleted *every site on the instance* in `@BeforeClass`
  and imported a checked-in `acmespace` archive. These specs create their own sites — named after
  what they test, plus a short `jfaker` token — and export their own archive, so nothing outside the
  suite is touched and two runs against the same instance cannot collide on the server names.
- **Cleanup in `after` hooks**, so a passing spec leaves nothing behind on the instance.
- **The `dependsOnMethods` chain is split by user-observable step**, per the QA-reviewed table, rather
  than by legacy method boundary.
- **Selectors and messages are sourced, not guessed:** ids come from the module's own JSPs
  (`createSite.jsp`, `editSite.jsp`, `view.jsp`, `displayImportContent.jsp`), asserted strings from
  `JahiaServerSettings_en.properties`.

## Test-environment change: one template set

`tests/provisioning-manifest-{build,snapshot}.yml` now install `org.jahia.qa/qa-templatesSet`.

The create-site wizard stops at its first step with *"You do not have any deployed template sets.
Please deploy some."* — no existing spec in this repo needed one, so the instance never had one.
`qa-templatesSet` (from `Jahia/QA-Modules`) declares `Jahia-Depends: default` only, so it adds
**exactly one bundle**. `dx-base-demo-templates` and `templates-web-blue` were tried first: neither
starts without ~20 component modules (`bookmarks`, `calendar`, `news`, …), which would have made every
integration run substantially heavier.

One thing for reviewers to weigh: `qa-templatesSet` is published as `1.0.0-SNAPSHOT` only. If the QA
team would rather not depend on a snapshot here, the alternative is a minimal template set of this
repo's own under `tests/jahia-module/` — more setup, fully self-contained. Happy to switch.

## New dependency: `yauzl`

FT-009 asserts on `site.properties` *inside the exported archive*, which is a zip nested in a zip, so
it cannot be done from the browser. `cypress/plugins/exportArchive.js` adds two Node tasks (find the
downloaded archive, read the nested `site.properties`) using `yauzl`. It was already in the tree as a
Cypress dependency; since the specs now use it directly it is declared in `tests/package.json` rather
than relied on transitively.

## Three traps, documented in the code

Worth knowing for anyone writing tests against these JSP admin screens — each cost real debugging time
here, and each is commented at the point of use:

1. **Iframe access must be a retryable query chain** — `cy.get().its('0.contentDocument.body').find()`.
   `cy.iframe()` (cypress-iframe) is a *command*, so Cypress cannot requery it; every wizard step is a
   POST that swaps the iframe's document, and the held body fails with *"the subject is no longer
   attached to the DOM"*. A `.should()` inside the helper re-freezes the chain and brings the bug back.
2. **`editSite.jsp` raises a native `confirm()` inside the iframe** when the server name changes.
   Cypress only auto-accepts dialogs on the top-level window under test, so the un-stubbed dialog
   blocks the browser itself: the run hangs indefinitely and **no Cypress timeout fires**. It is
   stubbed on the iframe's `contentWindow` in `EditSitePage.save()`.
3. **Every wizard step carries the same `[name="_eventId_next"]`**, so a step must be identified by a
   marker unique to it before clicking — otherwise the previous step's button is re-clicked while its
   document is being replaced.

## Follow-up

Once this merges, the legacy `CreateSitesTest` can be removed from `Jahia/selenium` (separate PR
there, as in Jahia/selenium#1596).
