### PR TITLE
fix: render server settings components only for server administrators

### DIFF
--- a/.chachalog/qnzGuWxa.md
+++ b/.chachalog/qnzGuWxa.md
@@ -1,0 +1,5 @@
+---
+serverSettings: patch
+---
+
+Render server settings components only for server administrators

--- a/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
@@ -52,13 +52,11 @@ import java.util.List;
  * Renders a settings component only when the caller holds an administration permission on the resource the
  * request is actually made against.
  * <p>
- * The server settings screens of this module are ordinary, instantiable content types, so the server
- * administration container they were designed for is not the only place they can be rendered from. The
- * permission each screen requires is declared on the settings <em>template</em> that hosts it
- * ({@code j:requiredPermissionNames}), so it is a property of that template and not of the component: the
- * same component rendered through any other resource — a plain page content area — carries no requirement at
- * all, and the Spring web flow behind it would be handed to whoever can render that resource. This filter
- * makes the requirement a property of the component, so it holds on every render path.
+ * The permission requirement belongs on the component, not only on the settings template that normally
+ * hosts it ({@code j:requiredPermissionNames}): a component's access rule should travel with the component
+ * and hold on every render path, regardless of where the component is placed. This filter makes the
+ * requirement a property of the component so it applies uniformly. Because {@code WebflowAction} re-enters
+ * the render chain for each webflow POST, it covers every transition too, not just the initial GET.
  * <p>
  * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
  * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings

--- a/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
@@ -44,11 +44,16 @@ import org.slf4j.LoggerFactory;
  * Failing to resolve a main resource, or a missing configuration, yields an empty fragment rather
  * than a rendered component.
  */
+// equals/hashCode are deliberately NOT overridden for the field below: AbstractFilter defines
+// equality as (concrete class, priority), which is the key RenderService.addFilter uses to replace an
+// already-registered filter. Widening it to the configuration would break that re-registration.
+@SuppressWarnings("java:S2160")
 public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
 
     private String[] requiredPermissions = new String[0];
+    private String requiredPermissionsLabel = "";
 
     /**
      * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any
@@ -62,6 +67,7 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
             parsed[i] = parsed[i].trim();
         }
         this.requiredPermissions = parsed;
+        this.requiredPermissionsLabel = StringUtils.join(parsed, ", ");
     }
 
     @Override
@@ -85,9 +91,11 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
             }
         }
 
-        logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
-                renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                StringUtils.join(requiredPermissions, ", "), contextNode.getPath());
+        if (logger.isWarnEnabled()) {
+            logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
+                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                    requiredPermissionsLabel, contextNode.getPath());
+        }
         return StringUtils.EMPTY;
     }
 }

--- a/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
@@ -104,10 +104,14 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     @Activate
     public void activate() {
-        // Priority 22: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
-        // before the fragment is produced or cached — a refusal must not populate a cache entry that a
-        // differently-privileged caller could later be served.
-        setPriority(22);
+        // Priority 21.5: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
+        // clear of the 22.x template band. AbstractFilter breaks a priority tie on the class name, so an exact
+        // 22 would order this against core's templateNodeFilter (22.0) by an accident of package naming rather
+        // than by intent; 21.5 states the intended slot instead of relying on that.
+        // This runs inside the fragment cache's generation scope (live only, 16 / 16.5), which is safe because
+        // that cache keys on the caller's ACL signature: an entry generated for an administrator is not served
+        // to a caller who lacks the grant.
+        setPriority(21.5f);
         setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
         setDescription("Renders a settings component only for a caller holding an administration permission "
                 + "on the main resource");

--- a/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
@@ -13,6 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Wiring note — this is deliberately OSGi Declarative Services, not a Spring bean.
+ *
+ * Jahia's engineering conventions (the shared `cortex` harness, skill
+ * `jahia-java-osgi-declarative-services`) state the rule as: DS is the ONLY dependency-injection
+ * mechanism allowed in a Jahia module — Blueprint is deprecated and Spring is forbidden, with the sole
+ * tolerated exception being a guarded `SpringContextSingleton.getBean(...)` read-through to a core bean.
+ * An earlier revision of this filter was registered as a Spring bean in META-INF/spring; it was moved
+ * here to follow that rule, and the render filter it registers behaves identically either way (both end
+ * up in JahiaTemplateManagerService.getRenderFilters()).
+ *
+ * The same harness documents the trap to watch for if this is ever ported to another module: without the
+ * bnd instruction `<_dsannotations>*</_dsannotations>`, an @Component class compiles and ships but emits
+ * no OSGI-INF descriptor and no Service-Component header, so the component silently never registers and
+ * the gate below simply does not run. Parents `jahia-modules` >= 8.1.7.0 switch it on already; older ones
+ * do not. Verify a descriptor is actually in the built jar rather than assuming.
+ */
 package org.jahia.modules.serversettings.render;
 
 import org.apache.commons.lang.StringUtils;
@@ -21,71 +38,96 @@ import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.filter.AbstractFilter;
 import org.jahia.services.render.filter.RenderChain;
+import org.jahia.services.render.filter.RenderFilter;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
- * Renders a settings component only when the caller holds an administration permission on the
- * resource the request is actually made against.
+ * Renders a settings component only when the caller holds an administration permission on the resource the
+ * request is actually made against.
  * <p>
- * The settings components of this module are ordinary, instantiable content types, so the container
- * they were designed for is not the only place they can end up being rendered from. The permission
- * requirements declared on the settings templates ({@code j:requiredPermissionNames}) are a property
- * of those templates, so a component rendered through any other resource carries no requirement at
- * all — and the flow behind it would then be handed to whoever can render that resource. This filter
- * makes the requirement a property of the component instead, so it holds on every render path.
+ * The server settings screens of this module are ordinary, instantiable content types, so the server
+ * administration container they were designed for is not the only place they can be rendered from. The
+ * permission each screen requires is declared on the settings <em>template</em> that hosts it
+ * ({@code j:requiredPermissionNames}), so it is a property of that template and not of the component: the
+ * same component rendered through any other resource — a plain page content area — carries no requirement at
+ * all, and the Spring web flow behind it would be handed to whoever can render that resource. This filter
+ * makes the requirement a property of the component, so it holds on every render path.
  * <p>
- * The check is evaluated against the <strong>main resource</strong> of the render, not against the
- * component node: the component node of a settings screen lives inside the module
- * ({@code /modules/&lt;module&gt;/...}), whereas the main resource of the server administration route
- * is the global settings node — the node the server administrator role is granted through. Checking
- * the component node instead would refuse legitimate administrators.
+ * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
+ * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings
+ * screen lives inside its module ({@code /modules/...}), where a site-scoped administrator holds nothing —
+ * measured, {@code site-admin} is {@code false} there and {@code true} on {@code /sites/<key>}. Checking
+ * the component node, which is the obvious implementation, would therefore refuse real site administrators.
+ * The main resource is the site (site-settings route) or the global settings node (server-administration
+ * route), which is what the corresponding administrator role is actually granted on.
  * <p>
- * Failing to resolve a main resource, or a missing configuration, yields an empty fragment rather
- * than a rendered component.
+ * Only {@code admin} is accepted, so these screens stay out of reach of an administrator whose authority is
+ * scoped to a single site. It is a core permission ({@code root-permissions.xml}) granted by the
+ * {@code server-administrator} role; the finer per-screen permissions are contributed by this module's own
+ * {@code permissions.xml} and resolve to {@code false} indistinguishably from a denial where they are not
+ * registered, which would fail closed for administrators too.
+ * The finer per-screen requirement declared on the settings template remains enforced on the administration
+ * route, so this filter is an additional condition and never a replacement. Failing to resolve a main resource
+ * yields an empty fragment rather than a rendered component.
+ * <p>
+ * Registered via OSGi Declarative Services — no Spring context involvement.
  */
-// equals/hashCode are deliberately NOT overridden for the field below: AbstractFilter defines
-// equality as (concrete class, priority), which is the key RenderService.addFilter uses to replace an
-// already-registered filter. Widening it to the configuration would break that re-registration.
-@SuppressWarnings("java:S2160")
+@Component(service = RenderFilter.class, immediate = true)
 public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
 
-    private String[] requiredPermissions = new String[0];
-    private String requiredPermissionsLabel = "";
+    /** Node types gated by this filter. */
+    private static final String APPLY_ON_NODE_TYPES = 
+            "jnt:serverSettingsAboutJahia," +
+            "jnt:serverSettingsAdminProperties," +
+            "jnt:serverSettingsCacheManagement," +
+            "jnt:serverSettingsDBSettings," +
+            "jnt:serverSettingsMailServerSettings," +
+            "jnt:serverSettingsManageMemory," +
+            "jnt:serverSettingsManagePortlets," +
+            "jnt:serverSettingsManageWebProjects," +
+            "jnt:serverSettingsPasswordPolicy," +
+            "jnt:serverSettingsReportAnIssue," +
+            "jnt:serverSettingsSystemInfos";
 
-    /**
-     * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any
-     * one of them on the main resource may render the component.
-     *
-     * @param requiredPermissions comma-separated list of permission names
-     */
-    public void setRequiredPermissions(String requiredPermissions) {
-        String[] parsed = StringUtils.split(StringUtils.defaultString(requiredPermissions), ',');
-        for (int i = 0; i < parsed.length; i++) {
-            parsed[i] = parsed[i].trim();
-        }
-        this.requiredPermissions = parsed;
-        this.requiredPermissionsLabel = StringUtils.join(parsed, ", ");
+    /** Any one of these on the main resource is sufficient. */
+    private static final List<String> REQUIRED_PERMISSIONS =
+            Collections.unmodifiableList(Arrays.asList("admin"));
+
+    private static final String REQUIRED_PERMISSIONS_LABEL = StringUtils.join(REQUIRED_PERMISSIONS, ", ");
+
+    @Activate
+    public void activate() {
+        // Priority 22: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
+        // before the fragment is produced or cached — a refusal must not populate a cache entry that a
+        // differently-privileged caller could later be served.
+        setPriority(22);
+        setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
+        setDescription("Renders a settings component only for a caller holding an administration permission "
+                + "on the main resource");
+        logger.debug("SettingsComponentPermissionFilter active on {}", APPLY_ON_NODE_TYPES);
     }
 
     @Override
     public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        if (requiredPermissions.length == 0) {
-            logger.error("No permission configured for {}; refusing to render {}",
-                    getClass().getName(), resource.getNodePath());
-            return StringUtils.EMPTY;
-        }
-
         Resource mainResource = renderContext.getMainResource();
         JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
         if (contextNode == null) {
+            // Fail closed: with no main resource there is nothing to evaluate the permission against, and this
+            // is an administration capability.
             logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
             return StringUtils.EMPTY;
         }
 
-        for (String permission : requiredPermissions) {
+        for (String permission : REQUIRED_PERMISSIONS) {
             if (contextNode.hasPermission(permission)) {
                 return null;
             }
@@ -94,7 +136,7 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
         if (logger.isWarnEnabled()) {
             logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
                     renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                    requiredPermissionsLabel, contextNode.getPath());
+                    REQUIRED_PERMISSIONS_LABEL, contextNode.getPath());
         }
         return StringUtils.EMPTY;
     }

--- a/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.serversettings.render;
+
+import org.apache.commons.lang.StringUtils;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.render.RenderContext;
+import org.jahia.services.render.Resource;
+import org.jahia.services.render.filter.AbstractFilter;
+import org.jahia.services.render.filter.RenderChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Renders a settings component only when the caller holds an administration permission on the
+ * resource the request is actually made against.
+ * <p>
+ * The settings components of this module are ordinary, instantiable content types, so the container
+ * they were designed for is not the only place they can end up being rendered from. The permission
+ * requirements declared on the settings templates ({@code j:requiredPermissionNames}) are a property
+ * of those templates, so a component rendered through any other resource carries no requirement at
+ * all — and the flow behind it would then be handed to whoever can render that resource. This filter
+ * makes the requirement a property of the component instead, so it holds on every render path.
+ * <p>
+ * The check is evaluated against the <strong>main resource</strong> of the render, not against the
+ * component node: the component node of a settings screen lives inside the module
+ * ({@code /modules/&lt;module&gt;/...}), whereas the main resource of the server administration route
+ * is the global settings node — the node the server administrator role is granted through. Checking
+ * the component node instead would refuse legitimate administrators.
+ * <p>
+ * Failing to resolve a main resource, or a missing configuration, yields an empty fragment rather
+ * than a rendered component.
+ */
+public class SettingsComponentPermissionFilter extends AbstractFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
+
+    private String[] requiredPermissions = new String[0];
+
+    /**
+     * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any
+     * one of them on the main resource may render the component.
+     *
+     * @param requiredPermissions comma-separated list of permission names
+     */
+    public void setRequiredPermissions(String requiredPermissions) {
+        String[] parsed = StringUtils.split(StringUtils.defaultString(requiredPermissions), ',');
+        for (int i = 0; i < parsed.length; i++) {
+            parsed[i] = parsed[i].trim();
+        }
+        this.requiredPermissions = parsed;
+    }
+
+    @Override
+    public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
+        if (requiredPermissions.length == 0) {
+            logger.error("No permission configured for {}; refusing to render {}",
+                    getClass().getName(), resource.getNodePath());
+            return StringUtils.EMPTY;
+        }
+
+        Resource mainResource = renderContext.getMainResource();
+        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
+        if (contextNode == null) {
+            logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
+            return StringUtils.EMPTY;
+        }
+
+        for (String permission : requiredPermissions) {
+            if (contextNode.hasPermission(permission)) {
+                return null;
+            }
+        }
+
+        logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
+                renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                StringUtils.join(requiredPermissions, ", "), contextNode.getPath());
+        return StringUtils.EMPTY;
+    }
+}

--- a/src/main/resources/META-INF/spring/serverSettings.xml
+++ b/src/main/resources/META-INF/spring/serverSettings.xml
@@ -16,16 +16,4 @@
         </property>
     </bean>
 
-    <!-- These components belong to the server-wide administration route, whose main resource is the
-         global settings node; the server administration permission is the only one accepted. -->
-    <bean id="serverSettingsComponentPermissionFilter"
-          class="org.jahia.modules.serversettings.render.SettingsComponentPermissionFilter">
-        <property name="priority" value="22"/>
-        <property name="description"
-                  value="Renders a server settings component only for a caller holding the server administration permission on the main resource"/>
-        <property name="applyOnNodeTypes"
-                  value="jnt:serverSettingsAboutJahia,jnt:serverSettingsAdminProperties,jnt:serverSettingsCacheManagement,jnt:serverSettingsDBSettings,jnt:serverSettingsMailServerSettings,jnt:serverSettingsManageMemory,jnt:serverSettingsManagePortlets,jnt:serverSettingsManageWebProjects,jnt:serverSettingsPasswordPolicy,jnt:serverSettingsReportAnIssue,jnt:serverSettingsSystemInfos"/>
-        <property name="requiredPermissions" value="admin"/>
-    </bean>
-
 </beans>

--- a/src/main/resources/META-INF/spring/serverSettings.xml
+++ b/src/main/resources/META-INF/spring/serverSettings.xml
@@ -16,4 +16,16 @@
         </property>
     </bean>
 
+    <!-- These components belong to the server-wide administration route, whose main resource is the
+         global settings node; the server administration permission is the only one accepted. -->
+    <bean id="serverSettingsComponentPermissionFilter"
+          class="org.jahia.modules.serversettings.render.SettingsComponentPermissionFilter">
+        <property name="priority" value="22"/>
+        <property name="description"
+                  value="Renders a server settings component only for a caller holding the server administration permission on the main resource"/>
+        <property name="applyOnNodeTypes"
+                  value="jnt:serverSettingsAboutJahia,jnt:serverSettingsAdminProperties,jnt:serverSettingsCacheManagement,jnt:serverSettingsDBSettings,jnt:serverSettingsMailServerSettings,jnt:serverSettingsManageMemory,jnt:serverSettingsManagePortlets,jnt:serverSettingsManageWebProjects,jnt:serverSettingsPasswordPolicy,jnt:serverSettingsReportAnIssue,jnt:serverSettingsSystemInfos"/>
+        <property name="requiredPermissions" value="admin"/>
+    </bean>
+
 </beans>

--- a/tests/cypress/e2e/settingsComponentRenderScope.cy.ts
+++ b/tests/cypress/e2e/settingsComponentRenderScope.cy.ts
@@ -1,9 +1,8 @@
-// Render scope of the server settings components. These screens are ordinary, instantiable content
-// types, so the server administration container they were designed for is not the only place they can
-// be rendered from. This spec places one of them in a plain page content area — i.e. outside that
-// container — and asserts that the web flow behind it is only served to a caller holding server
-// administration, and in particular NOT to a site administrator, whose authority stops at one site.
-// Opaque by design.
+// Render scope of the server settings components. A component's access rule should travel with the
+// component and hold on every render path, regardless of where the component is placed — not only on the
+// settings template that normally hosts it. This spec renders one of these components through an ordinary
+// resource and asserts that its web flow remains available only to a caller holding server administration,
+// and in particular NOT to a site administrator, whose authority stops at one site.
 //
 // Non-vacuity: the negative assertions are paired with a POSITIVE CONTROL that goes through the exact
 // same request shape and asserts the flow IS served to a server administrator, so a fixture that

--- a/tests/cypress/e2e/settingsComponentRenderScope.cy.ts
+++ b/tests/cypress/e2e/settingsComponentRenderScope.cy.ts
@@ -1,0 +1,91 @@
+// Render scope of the server settings components. These screens are ordinary, instantiable content
+// types, so the server administration container they were designed for is not the only place they can
+// be rendered from. This spec places one of them in a plain page content area — i.e. outside that
+// container — and asserts that the web flow behind it is only served to a caller holding server
+// administration, and in particular NOT to a site administrator, whose authority stops at one site.
+// Opaque by design.
+//
+// Non-vacuity: the negative assertions are paired with a POSITIVE CONTROL that goes through the exact
+// same request shape and asserts the flow IS served to a server administrator, so a fixture that
+// renders nothing cannot produce a false green. The site-administrator case doubles as a sharper
+// control: that account is a real administrator of the hosting site and can read the page, so its
+// refusal isolates the requirement to server administration rather than to "being logged in" or
+// "being some kind of administrator".
+//
+// Fully self-contained: creates its own site, the accounts and the placed component in before();
+// tears everything down in after().
+import { createSite, deleteSite, createUser, deleteUser, grantRoles, addNode } from '@jahia/cypress'
+
+describe('Server settings components - render scope', () => {
+    const uniq = Date.now().toString(36)
+    const site = 'srvRenderScope' + uniq
+
+    const serverAdmin = 'srvscopeserver' + uniq // server administration, granted at the repository root
+    const siteAdmin = 'srvscopesite' + uniq // administers the hosting site only
+    const lowPriv = 'srvscopelow' + uniq // ordinary account, administers nothing
+
+    const placed = 'placedCacheManagement' + uniq
+    const area = `/sites/${site}/home/pagecontent`
+    const pageUrl = `/cms/render/default/en/sites/${site}/home.html`
+
+    before(() => {
+        cy.login()
+        createSite(site, { languages: 'en', templateSet: 'templates-system', serverName: 'localhost', locale: 'en' })
+
+        createUser(serverAdmin, 'password')
+        createUser(siteAdmin, 'password')
+        createUser(lowPriv, 'password')
+
+        grantRoles('/', ['server-administrator'], serverAdmin, 'USER')
+        grantRoles(`/sites/${site}`, ['site-administrator'], siteAdmin, 'USER')
+        grantRoles(`/sites/${site}`, ['editor'], lowPriv, 'USER')
+
+        // the server administrator must also be able to read the hosting site, so the positive control
+        // measures the component and not the site's read ACL
+        grantRoles(`/sites/${site}`, ['editor'], serverAdmin, 'USER')
+
+        addNode({ parentPathOrId: `/sites/${site}/home`, primaryNodeType: 'jnt:contentList', name: 'pagecontent' })
+        addNode({ parentPathOrId: area, primaryNodeType: 'jnt:serverSettingsCacheManagement', name: placed })
+    })
+
+    after(() => {
+        cy.login()
+        deleteUser(serverAdmin)
+        deleteUser(siteAdmin)
+        deleteUser(lowPriv)
+        deleteSite(site)
+    })
+
+    // Render the hosting page as whoever is logged in and report how many flow execution keys were
+    // served. Without one there is no flow to drive.
+    const flowsServed = (user: string) => {
+        cy.login(user, 'password')
+        return cy
+            .request({ url: pageUrl, failOnStatusCode: false, qs: { ec: uniq + Math.floor(Math.random() * 1e6) } })
+            .then((res) => {
+                const body = typeof res.body === 'string' ? res.body : ''
+                return { status: res.status, served: (body.match(/webflowexecution/g) || []).length }
+            })
+    }
+
+    it('serves the flow of the placed component to a server administrator (positive control)', () => {
+        flowsServed(serverAdmin).then(({ status, served }) => {
+            expect(status, 'the server administrator must be able to read the hosting page').to.eq(200)
+            expect(served, 'the server administrator must still be served the flow').to.be.greaterThan(0)
+        })
+    })
+
+    it('does not serve the flow to an administrator of the hosting site only', () => {
+        flowsServed(siteAdmin).then(({ status, served }) => {
+            expect(status, 'the site administrator must be able to read the hosting page').to.eq(200)
+            expect(served, 'a site administrator must not be served a server administration flow').to.eq(0)
+        })
+    })
+
+    it('does not serve the flow to a caller that administers nothing', () => {
+        flowsServed(lowPriv).then(({ status, served }) => {
+            expect(status, 'the low-privilege account must be able to read the hosting page').to.eq(200)
+            expect(served, 'no flow may be served to a caller that administers nothing').to.eq(0)
+        })
+    })
+})


### PR DESCRIPTION
## Summary

The permission requirement belongs on the **component**, not only on the settings template that normally
hosts it (`j:requiredPermissionNames`): a component's access rule should travel with the component and hold on
every render path, regardless of where the component is placed. This module's settings screens are ordinary, instantiable content types, so the requirement is made a property of each component.

## Change

A render filter (`SettingsComponentPermissionFilter`, priority 21.5) applied on this module's eleven `jnt:serverSettings*` node types, registered via
**OSGi Declarative Services**. When the caller holds none of the accepted permissions it returns an empty
fragment — core's own semantics in `TemplatePermissionCheckFilter`. Because `WebflowAction` re-enters the
render chain for each webflow POST, every transition is covered too, not just the initial GET.

**The check is evaluated on the render's MAIN RESOURCE, not on the component node.** This is the
counter-intuitive part and it is load-bearing: the component node of a legitimate settings screen lives inside
its module (`/modules/...`), where a site-scoped administrator holds nothing — measured, `site-admin` is
`false` there and `true` on `/sites/<key>`. Checking the component node, which is the obvious implementation,
would refuse real site administrators. The main resource is the site (site-settings route) or the global
settings node (server-administration route), which is what each administrator role is granted on.

Only `admin` is accepted, so these screens stay out of reach of an administrator whose authority is scoped to a
single site. It is a core permission (`root-permissions.xml`) granted by the `server-administrator` role. The
finer per-screen permissions are contributed by this module's own `permissions.xml` and resolve to `false` where
they are not registered on an instance, which would fail closed for administrators too; the finer requirement
still applies on the administration route via the template.

## Verification

Measured on 8.2.4.0-SNAPSHOT, counting the Spring WebFlow execution keys a render serves (without one there is
no flow to drive):

| caller | flow served |
|---|---|
| `root` | yes |
| server administrator | yes |
| administrator of one site | no |
| ordinary editor | no |

Controls, so the negatives mean what they say: every caller in the table can read the hosting page (HTTP 200),
so a "no" is a permission decision and not an unreadable node; `root` cannot be refused by this mechanism at
all, since core short-circuits permission checks for administrators; and a server administrator is unaffected
throughout, which is the no-over-blocking control. A self-contained Cypress spec asserts the same invariant in CI, including that a site administrator is refused — which isolates the requirement to server administration rather than to being any kind of administrator.

## Notes

- Registered via DS rather than a Spring bean, per Jahia's convention that DS is the only DI mechanism for
  module code. Both routes register into `JahiaTemplateManagerService.getRenderFilters()`; verified live at
  priority 22, which is the value that measurement was taken at (see the priority note below).
- `equals`/`hashCode` are deliberately not overridden: `AbstractFilter` defines equality as
  (concrete class, priority), which is the key `RenderService.addFilter` uses to replace an already-registered
  filter. Widening it would break that re-registration.
- Studio rendering is not special-cased: core skips its own permission checks in `studiomode`, this filter does
  not. A template developer previewing the component in studio without an administration permission will get an
  empty fragment.

- Placement is deliberately left unconstrained in the nodetype definitions. The condition holds wherever the
  component renders — which is exactly what the off-container placement in the spec exercises — so a
  definition-level restriction would be belt-and-braces rather than the load-bearing control. Recorded here so
  it does not read as an oversight.
- Priority is 21.5, not 22. An exact 22 tied with core's `templateNodeFilter` (22.0); `AbstractFilter` breaks
  such a tie on the class name, so the resulting order held by an accident of package naming. 21.5 states the
  intended slot — immediately after core's permission check at 21, clear of the 22.x template band — directly.
  No behavioural change: 22 already ordered ahead of `templateNodeFilter`.
