### PR TITLE
fix: check the caller administers the server before saving administration properties

### DIFF
--- a/.chachalog/4bJc0uEL.md
+++ b/.chachalog/4bJc0uEL.md
@@ -1,0 +1,5 @@
+---
+serverSettings: patch
+---
+
+Check the caller administers the server before saving administration properties

--- a/src/main/java/org/jahia/modules/serversettings/flow/AdminPropertiesHandler.java
+++ b/src/main/java/org/jahia/modules/serversettings/flow/AdminPropertiesHandler.java
@@ -64,7 +64,7 @@ import java.util.List;
 
 public class AdminPropertiesHandler implements Serializable {
     private static final long serialVersionUID = -1665000223980422529L;
-    private transient static final Logger logger = LoggerFactory.getLogger(AdminPropertiesHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(AdminPropertiesHandler.class);
 
     /**
      * Permission the caller must hold to write the root account's properties through this screen.
@@ -110,33 +110,36 @@ public class AdminPropertiesHandler implements Serializable {
         }
 
         try {
-            if (!rootNode.hasProperty("j:lastName") || !StringUtils.equals(rootNode.getProperty("j:lastName").getString(), adminProperties.getLastName())) {
-                rootNode.setProperty("j:lastName", adminProperties.getLastName());
-            }
-            if (!rootNode.hasProperty("j:firstName") || !StringUtils.equals(rootNode.getProperty("j:firstName").getString(), adminProperties.getFirstName())) {
-                rootNode.setProperty("j:firstName", adminProperties.getFirstName());
-            }
-            if (!rootNode.hasProperty("j:organization") || !StringUtils.equals(rootNode.getProperty("j:organization").getString(), adminProperties.getOrganization())) {
-                rootNode.setProperty("j:organization", adminProperties.getOrganization());
-            }
-            if (!rootNode.hasProperty("emailNotificationsDisabled") || !StringUtils.equals(rootNode.getProperty("emailNotificationsDisabled").getString(), adminProperties
-                    .getEmailNotificationsDisabled().toString())) {
-                rootNode.setProperty("emailNotificationsDisabled",
-                        Boolean.toString(adminProperties.getEmailNotificationsDisabled()));
-            }
-            if (!rootNode.hasProperty("j:email") || !StringUtils.equals(rootNode.getProperty("j:email").getString(), adminProperties.getEmail())) {
-                rootNode.setProperty("j:email", adminProperties.getEmail());
-            }
-            String lang = adminProperties.getPreferredLanguage().toString();
-            if (!rootNode.hasProperty("preferredLanguage") || !StringUtils.equals(rootNode.getProperty("preferredLanguage").getString(), lang)) {
-                rootNode.setProperty("preferredLanguage", lang);
-            }
+            setIfChanged(rootNode, "j:lastName", adminProperties.getLastName());
+            setIfChanged(rootNode, "j:firstName", adminProperties.getFirstName());
+            setIfChanged(rootNode, "j:organization", adminProperties.getOrganization());
+            setIfChanged(rootNode, "emailNotificationsDisabled",
+                    Boolean.toString(adminProperties.getEmailNotificationsDisabled()));
+            setIfChanged(rootNode, "j:email", adminProperties.getEmail());
+            setIfChanged(rootNode, "preferredLanguage", adminProperties.getPreferredLanguage().toString());
             messages.addMessage(new MessageBuilder().info().code("label.changeSaved").build());
 
             rootNode.save();
         } catch (RepositoryException e) {
             messages.addMessage(new MessageBuilder().error().code("label.error").build());
             logger.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Writes {@code value} to {@code name} when the node does not already hold exactly that value.
+     * <p>
+     * The six properties this screen edits share one read-compare-write shape; expressing it once keeps each
+     * of them a single line and keeps the comparison identical across all of them.
+     *
+     * @param node the node to write to
+     * @param name the property name
+     * @param value the value the property should hold
+     * @throws RepositoryException if reading or writing the property fails
+     */
+    private static void setIfChanged(JCRUserNode node, String name, String value) throws RepositoryException {
+        if (!node.hasProperty(name) || !StringUtils.equals(node.getProperty(name).getString(), value)) {
+            node.setProperty(name, value);
         }
     }
 

--- a/src/main/java/org/jahia/modules/serversettings/flow/AdminPropertiesHandler.java
+++ b/src/main/java/org/jahia/modules/serversettings/flow/AdminPropertiesHandler.java
@@ -45,10 +45,11 @@ package org.jahia.modules.serversettings.flow;
 
 import org.apache.commons.lang.StringUtils;
 import org.jahia.modules.serversettings.users.admin.AdminProperties;
-import org.jahia.services.content.JCRContentUtils;
+import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.decorator.JCRGroupNode;
 import org.jahia.services.content.decorator.JCRUserNode;
 import org.jahia.services.render.RenderContext;
+import org.jahia.services.render.Resource;
 import org.jahia.services.usermanager.JahiaUserManagerService;
 import org.jahia.taglibs.user.User;
 import org.slf4j.Logger;
@@ -63,7 +64,19 @@ import java.util.List;
 
 public class AdminPropertiesHandler implements Serializable {
     private static final long serialVersionUID = -1665000223980422529L;
-    private transient static final Logger logger = LoggerFactory.getLogger(JCRContentUtils.class);
+    private transient static final Logger logger = LoggerFactory.getLogger(AdminPropertiesHandler.class);
+
+    /**
+     * Permission the caller must hold to write the root account's properties through this screen.
+     * <p>
+     * Same requirement, evaluated on the same node, as
+     * {@code org.jahia.modules.serversettings.render.SettingsComponentPermissionFilter}: {@code admin} is a
+     * core permission granted by the {@code server-administrator} role, and it is deliberately not one of the
+     * finer per-screen permissions, which resolve to {@code false} where they are not registered on an
+     * instance and would therefore fail closed for administrators too.
+     */
+    private static final String REQUIRED_PERMISSION = "admin";
+
     private AdminProperties adminProperties;
 
     public AdminProperties getAdminProperties() {
@@ -80,8 +93,17 @@ public class AdminPropertiesHandler implements Serializable {
 
     /**
      * save the bean in the JCR
+     * <p>
+     * Every write below targets the root account, so the caller's authority is established once, on entry,
+     * and covers the method as a whole — the screen is administrative in its entirety, and each property it
+     * writes carries the same requirement.
      */
     public void save(MessageContext messages, RenderContext renderContext) {
+        if (!isAdministrationGranted(renderContext)) {
+            messages.addMessage(new MessageBuilder().error().code("label.error").build());
+            return;
+        }
+
         JCRUserNode rootNode = JahiaUserManagerService.getInstance().lookupRootUser();
         if (renderContext.getUser().isRoot() && !StringUtils.isEmpty(adminProperties.getPassword())) {
             rootNode.setPassword(adminProperties.getPassword());
@@ -117,6 +139,43 @@ public class AdminPropertiesHandler implements Serializable {
             logger.error(e.getMessage(), e);
         }
     }
+
+    /**
+     * Whether the caller may write the root account's properties.
+     * <p>
+     * The requirement is evaluated on the render's <strong>main resource</strong> — the site or the global
+     * settings node the request is actually made against, which is what an administrator role is granted on.
+     * That target is load-bearing: the root user node this method writes is obtained through a system
+     * session, and {@code hasPermission} answers {@code true} for any caller on such a session, so it can
+     * express no requirement. The main resource is bound to the caller's own session and does.
+     * <p>
+     * Fails closed: without a main resource there is nothing to evaluate the requirement against, and this is
+     * an administration capability.
+     *
+     * @param renderContext the context of the render the transition was submitted from
+     * @return {@code true} when the caller holds {@link #REQUIRED_PERMISSION} on the main resource
+     */
+    private boolean isAdministrationGranted(RenderContext renderContext) {
+        Resource mainResource = renderContext != null ? renderContext.getMainResource() : null;
+        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
+        if (contextNode == null) {
+            logger.warn("No main resource to evaluate {} against; not saving the administration properties",
+                    REQUIRED_PERMISSION);
+            return false;
+        }
+
+        if (contextNode.hasPermission(REQUIRED_PERMISSION)) {
+            return true;
+        }
+
+        if (logger.isWarnEnabled()) {
+            logger.warn("Not saving the administration properties: {} does not hold {} on {}",
+                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                    REQUIRED_PERMISSION, contextNode.getPath());
+        }
+        return false;
+    }
+
     public List<JCRGroupNode> getUserMembership() {
         return new LinkedList<JCRGroupNode>(User.getUserMembership(JahiaUserManagerService.getInstance().lookupRootUser().getName()).values());
     }

--- a/tests/cypress/e2e/adminPropertiesWriteScope.cy.ts
+++ b/tests/cypress/e2e/adminPropertiesWriteScope.cy.ts
@@ -1,0 +1,137 @@
+// Write scope of the administration-properties screen. The screen edits the root account, and every
+// property it writes carries the same administration requirement, so the requirement holds for the save
+// as a whole. This spec drives the screen's save transition through a component placed on an ordinary
+// page and asserts that the root account only ever changes when the caller administers the server.
+//
+// Non-vacuity: the negative assertion is paired with a POSITIVE CONTROL that goes through the exact same
+// request shape and asserts the save DOES land for a server administrator. Without it, a fixture that
+// fails to submit anything at all would produce a false green — the root account would be unchanged for
+// the boring reason that nothing was ever driven.
+//
+// The low-privilege account is a real editor of the hosting site, so it can read the page. That makes its
+// refusal a decision about administering the server, and not about being unable to reach the screen.
+//
+// Fully self-contained: creates its own site, the accounts and the placed component in before(); restores
+// the root account and tears everything down in after().
+import { createSite, deleteSite, createUser, deleteUser, grantRoles, addNode } from '@jahia/cypress'
+
+/** What the screen did with a submitted save: was a flow served at all, and did it acknowledge a save. */
+interface SubmitOutcome {
+    served: boolean
+    saved: boolean
+}
+
+describe('Administration properties - write scope', () => {
+    const uniq = Date.now().toString(36)
+    const site = 'admPropScope' + uniq
+
+    const serverAdmin = 'admpropserver' + uniq // administers the server
+    const lowPriv = 'admproplow' + uniq // edits the hosting site, administers nothing
+
+    const placed = 'placedAdminProperties' + uniq
+    const area = `/sites/${site}/home/pagecontent`
+    const componentUrl = `/cms/render/default/en${area}/${placed}.html.ajax`
+
+    // Captured before anything is driven and put back in after(), so a failing run cannot leave the
+    // instance's root account rewritten.
+    let originalEmail = ''
+
+    const graphql = (query: string, variables: Record<string, unknown> = {}) =>
+        cy
+            .request({ method: 'POST', url: '/modules/graphql', body: { query, variables } })
+            .then((r) => r.body?.data)
+
+    const rootEmail = () =>
+        graphql(`{ jcr { nodeByPath(path: "/users/root") { property(name: "j:email") { value } } } }`).then(
+            (data) => (data?.jcr?.nodeByPath?.property?.value as string) ?? '',
+        )
+
+    const setRootEmail = (value: string) =>
+        graphql(
+            `mutation setRootEmail($value: String!) {
+                jcr { mutateNode(pathOrId: "/users/root") { mutateProperty(name: "j:email") { setValue(value: $value) } } }
+            }`,
+            { value },
+        )
+
+    // Render the placed component as the given user, then submit its save transition with the supplied
+    // email. Reports whether a flow was served at all and whether the screen acknowledged a save, so a
+    // refused render and a refused save are told apart.
+    const submitEmail = (user: string, email: string): Cypress.Chainable<SubmitOutcome> => {
+        cy.login(user, 'password')
+        return cy.request({ url: componentUrl, qs: { ec: uniq }, failOnStatusCode: false }).then((render) => {
+            const body = typeof render.body === 'string' ? render.body : ''
+            const action = /<form[^>]*id="adminProperties"[^>]*action="([^"]+)"/.exec(body)
+            if (!action) {
+                return cy.wrap<SubmitOutcome>({ served: false, saved: false }, { log: false })
+            }
+
+            return cy
+                .request({
+                    method: 'POST',
+                    url: action[1].replace(/&amp;/g, '&'),
+                    form: true,
+                    failOnStatusCode: false,
+                    body: {
+                        firstName: '',
+                        lastName: '',
+                        organization: '',
+                        email,
+                        _emailNotificationsDisabled: 'on',
+                        preferredLanguage: 'en',
+                        _eventId_submit: 'Save',
+                    },
+                })
+                .then((submit): SubmitOutcome => {
+                    const out = typeof submit.body === 'string' ? submit.body : ''
+                    return { served: true, saved: /alert-success/.test(out) }
+                })
+        })
+    }
+
+    before(() => {
+        cy.login()
+        createSite(site, { languages: 'en', templateSet: 'templates-system', serverName: 'localhost', locale: 'en' })
+
+        createUser(serverAdmin, 'password')
+        createUser(lowPriv, 'password')
+
+        grantRoles('/', ['server-administrator'], serverAdmin, 'USER')
+        // both accounts must be able to read the hosting page, so a refusal is never just an unreadable node
+        grantRoles(`/sites/${site}`, ['editor'], serverAdmin, 'USER')
+        grantRoles(`/sites/${site}`, ['editor'], lowPriv, 'USER')
+
+        addNode({ parentPathOrId: `/sites/${site}/home`, primaryNodeType: 'jnt:contentList', name: 'pagecontent' })
+        addNode({ parentPathOrId: area, primaryNodeType: 'jnt:serverSettingsAdminProperties', name: placed })
+
+        rootEmail().then((value) => {
+            originalEmail = value
+        })
+    })
+
+    after(() => {
+        cy.login()
+        setRootEmail(originalEmail)
+        deleteUser(serverAdmin)
+        deleteUser(lowPriv)
+        deleteSite(site)
+    })
+
+    it('lets a server administrator save the root account (positive control)', () => {
+        const email = `admprop-control-${uniq}@jahia.invalid`
+        submitEmail(serverAdmin, email).then((result) => {
+            expect(result.served, 'the server administrator must be served the flow').to.eq(true)
+            expect(result.saved, 'the server administrator must be able to save').to.eq(true)
+        })
+        cy.login()
+        rootEmail().should('eq', email)
+    })
+
+    it('does not let a caller that administers nothing rewrite the root account', () => {
+        const email = `admprop-attempt-${uniq}@jahia.invalid`
+        submitEmail(lowPriv, email)
+        cy.login()
+        // whether the render was refused or the save was, the account must be untouched
+        rootEmail().should('not.eq', email)
+    })
+})

--- a/tests/cypress/e2e/adminPropertiesWriteScope.cy.ts
+++ b/tests/cypress/e2e/adminPropertiesWriteScope.cy.ts
@@ -6,10 +6,15 @@
 // Non-vacuity: the negative assertion is paired with a POSITIVE CONTROL that goes through the exact same
 // request shape and asserts the save DOES land for a server administrator. Without it, a fixture that
 // fails to submit anything at all would produce a false green — the root account would be unchanged for
-// the boring reason that nothing was ever driven.
+// the boring reason that nothing was ever driven. The negative case also pins the account to its exact
+// pre-attempt value rather than merely "not the attempted one", which a failed read would satisfy too.
 //
 // The low-privilege account is a real editor of the hosting site, so it can read the page. That makes its
 // refusal a decision about administering the server, and not about being unable to reach the screen.
+//
+// State is read back THROUGH THE SCREEN, as an administrator, rather than through a content API: the
+// rendered form is populated from the stored root account, so it observes the same state with nothing but
+// the mechanism already under test — no second API surface to be gated or shaped differently.
 //
 // Fully self-contained: creates its own site, the accounts and the placed component in before(); restores
 // the root account and tears everything down in after().
@@ -36,47 +41,31 @@ describe('Administration properties - write scope', () => {
     // instance's root account rewritten.
     let originalEmail = ''
 
-    const graphql = (query: string, variables: Record<string, unknown> = {}) =>
-        cy.request({ method: 'POST', url: '/modules/graphql', body: { query, variables } }).then((r) => r.body?.data)
+    // Every render gets its own cache-buster: a repeated one would let the fragment cache answer, and a
+    // stale fragment reads exactly like "the value did not change".
+    let probe = 0
+    const ec = () => `${uniq}-${probe++}`
 
-    const rootEmail = () =>
-        graphql(
-            `
-                {
-                    jcr {
-                        nodeByPath(path: "/users/root") {
-                            property(name: "j:email") {
-                                value
-                            }
-                        }
-                    }
-                }
-            `,
-        ).then((data) => (data?.jcr?.nodeByPath?.property?.value as string) ?? '')
+    const render = (user: string) => {
+        cy.login(user, 'password')
+        return cy
+            .request({ url: componentUrl, qs: { ec: ec() }, failOnStatusCode: false })
+            .then((res) => (typeof res.body === 'string' ? res.body : ''))
+    }
 
-    const setRootEmail = (value: string) =>
-        graphql(
-            `
-                mutation setRootEmail($value: String!) {
-                    jcr {
-                        mutateNode(pathOrId: "/users/root") {
-                            mutateProperty(name: "j:email") {
-                                setValue(value: $value)
-                            }
-                        }
-                    }
-                }
-            `,
-            { value },
-        )
+    // The email the screen currently holds for the root account, as seen by a caller who may see it.
+    const storedEmail = (user: string) =>
+        render(user).then((body) => {
+            const field = /name="email"[^>]*value="([^"]*)"/.exec(body)
+            expect(field, `the screen must render its email field to ${user}`).to.not.eq(null)
+            return Cypress.$('<textarea/>').html(field[1]).text()
+        })
 
     // Render the placed component as the given user, then submit its save transition with the supplied
     // email. Reports whether a flow was served at all and whether the screen acknowledged a save, so a
     // refused render and a refused save are told apart.
-    const submitEmail = (user: string, email: string): Cypress.Chainable<SubmitOutcome> => {
-        cy.login(user, 'password')
-        return cy.request({ url: componentUrl, qs: { ec: uniq }, failOnStatusCode: false }).then((render) => {
-            const body = typeof render.body === 'string' ? render.body : ''
+    const submitEmail = (user: string, email: string): Cypress.Chainable<SubmitOutcome> =>
+        render(user).then((body) => {
             const action = /<form[^>]*id="adminProperties"[^>]*action="([^"]+)"/.exec(body)
             if (!action) {
                 return cy.wrap<SubmitOutcome>({ served: false, saved: false }, { log: false })
@@ -103,7 +92,6 @@ describe('Administration properties - write scope', () => {
                     return { served: true, saved: /alert-success/.test(out) }
                 })
         })
-    }
 
     before(() => {
         cy.login()
@@ -120,14 +108,15 @@ describe('Administration properties - write scope', () => {
         addNode({ parentPathOrId: `/sites/${site}/home`, primaryNodeType: 'jnt:contentList', name: 'pagecontent' })
         addNode({ parentPathOrId: area, primaryNodeType: 'jnt:serverSettingsAdminProperties', name: placed })
 
-        rootEmail().then((value) => {
+        storedEmail(serverAdmin).then((value) => {
             originalEmail = value
         })
     })
 
     after(() => {
+        // put the account back the way it was found, through the same screen
+        submitEmail(serverAdmin, originalEmail)
         cy.login()
-        setRootEmail(originalEmail)
         deleteUser(serverAdmin)
         deleteUser(lowPriv)
         deleteSite(site)
@@ -139,15 +128,17 @@ describe('Administration properties - write scope', () => {
             expect(result.served, 'the server administrator must be served the flow').to.eq(true)
             expect(result.saved, 'the server administrator must be able to save').to.eq(true)
         })
-        cy.login()
-        rootEmail().should('eq', email)
+        storedEmail(serverAdmin).should('eq', email)
     })
 
     it('does not let a caller that administers nothing rewrite the root account', () => {
         const email = `admprop-attempt-${uniq}@jahia.invalid`
-        submitEmail(lowPriv, email)
-        cy.login()
-        // whether the render was refused or the save was, the account must be untouched
-        rootEmail().should('not.eq', email)
+        storedEmail(serverAdmin).then((before) => {
+            submitEmail(lowPriv, email).then((result) => {
+                expect(result.saved, 'a caller that administers nothing must not be able to save').to.eq(false)
+            })
+            // pinned to the exact pre-attempt value: "not the attempted one" would also pass on a failed read
+            storedEmail(serverAdmin).should('eq', before)
+        })
     })
 })

--- a/tests/cypress/e2e/adminPropertiesWriteScope.cy.ts
+++ b/tests/cypress/e2e/adminPropertiesWriteScope.cy.ts
@@ -37,20 +37,36 @@ describe('Administration properties - write scope', () => {
     let originalEmail = ''
 
     const graphql = (query: string, variables: Record<string, unknown> = {}) =>
-        cy
-            .request({ method: 'POST', url: '/modules/graphql', body: { query, variables } })
-            .then((r) => r.body?.data)
+        cy.request({ method: 'POST', url: '/modules/graphql', body: { query, variables } }).then((r) => r.body?.data)
 
     const rootEmail = () =>
-        graphql(`{ jcr { nodeByPath(path: "/users/root") { property(name: "j:email") { value } } } }`).then(
-            (data) => (data?.jcr?.nodeByPath?.property?.value as string) ?? '',
-        )
+        graphql(
+            `
+                {
+                    jcr {
+                        nodeByPath(path: "/users/root") {
+                            property(name: "j:email") {
+                                value
+                            }
+                        }
+                    }
+                }
+            `,
+        ).then((data) => (data?.jcr?.nodeByPath?.property?.value as string) ?? '')
 
     const setRootEmail = (value: string) =>
         graphql(
-            `mutation setRootEmail($value: String!) {
-                jcr { mutateNode(pathOrId: "/users/root") { mutateProperty(name: "j:email") { setValue(value: $value) } } }
-            }`,
+            `
+                mutation setRootEmail($value: String!) {
+                    jcr {
+                        mutateNode(pathOrId: "/users/root") {
+                            mutateProperty(name: "j:email") {
+                                setValue(value: $value)
+                            }
+                        }
+                    }
+                }
+            `,
             { value },
         )
 


### PR DESCRIPTION
## Summary

The administration-properties screen edits the **root account**. Its save transition writes six properties
of that account — `j:lastName`, `j:firstName`, `j:organization`, `emailNotificationsDisabled`, `j:email`
and `preferredLanguage` — so the authority to use the screen belongs to the save as a whole, at the same
altitude as the screen itself, rather than to any individual field.

This makes that requirement explicit in the handler, which is the point closest to the write and the last
one on every route that reaches it.

## Change

`AdminPropertiesHandler.save()` establishes the caller's authority once, on entry, and returns with the
screen's existing `label.error` message when it is not held. The password write keeps its own, stricter
`isRoot()` condition on top; behaviour on the administrative path is unchanged.

The requirement is `admin` evaluated on the render's **main resource** — the same requirement, on the same
node, as `SettingsComponentPermissionFilter` (#228), so the two enforcement points agree by construction.
That evaluation target is load-bearing rather than incidental: the root user node the method writes is
obtained through a **system session**, where `hasPermission` answers `true` for any caller and can express
no requirement at all. The main resource is bound to the caller's own session, and is what the
`server-administrator` role is granted on. With no main resource to evaluate against, it fails closed.

Also here: the class logger was built from `JCRContentUtils.class`, so this class's messages were filed
under an unrelated logger; it now names its own class, which is what makes the message above findable.

## Verification

Measured on 8.2.4.0-SNAPSHOT, by driving the screen's save transition end to end against a component placed
in an ordinary page content list and reading `/users/root` back afterwards:

| caller | flow served | save acknowledged | root account |
|---|---|---|---|
| `root` | yes | yes | written |
| server administrator | yes | yes | written |
| editor of the hosting site | no | — | unchanged |

Both administrators go through the identical request shape as the third caller, so the last row is a
decision and not a fixture that failed to submit anything — the no-over-blocking control and the
non-vacuity control in one table.

To measure **this** check on its own rather than the filter in front of it, the same matrix was re-run with
`SettingsComponentPermissionFilter` unregistered (a throwaway local build, not part of this PR): the editor
is then served the flow and the save is declined, with the root account unchanged, against a `main` build of
the same commit where the same request is acknowledged. The handler's own decision is therefore measured,
not inferred from the layer above it.

A self-contained Cypress spec (`adminPropertiesWriteScope.cy.ts`) asserts the same invariant in CI: it
creates its own site, accounts and placed component, drives the save as a server administrator (which must
succeed) and as a caller who administers nothing, restores the root account and tears the fixture down.
