### PR TITLE
fix: align settings component rendering with the permissions its template declares

### DIFF
--- a/.chachalog/qnzGuWxa.md
+++ b/.chachalog/qnzGuWxa.md
@@ -2,4 +2,4 @@
 serverSettings: patch
 ---
 
-Render server settings components only for server administrators
+Render each server settings screen from its settings template, for the administrators that template requires.

--- a/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
@@ -62,6 +62,18 @@ import java.util.regex.Pattern;
  * this module's CND as {@code jmix:studioOnly} and ship neither a view nor a template, so they declare no
  * requirement and render nothing.
  * <p>
+ * Which condition does the work. Core enforces the same requirement on the same context resource before
+ * this filter runs: {@code TemplatePermissionCheckFilter} sits at priority 21 and restricts no node type.
+ * On the administration route, condition 2 therefore agrees with core rather than adding to it. Condition 1
+ * has no equivalent in core, because the gated node types carry no {@code jmix:requiredPermissions}
+ * of their own and this module declares no view-level {@code requirePermissions}. Read this class as a
+ * placement guard first.
+ * <p>
+ * Condition 2 still earns its place. Where the nearest declaring ancestor declares no requirement, core allows the render and this
+ * filter refuses it. That branch is live here: the three studio-only node types ship no template, so
+ * nothing declares a requirement for them. It also does not depend on
+ * core running first, so it still holds if the filter order changes.
+ * <p>
  * The permissions are evaluated against the render's <strong>context resource</strong> — the main resource,
  * or the ajax resource for an ajax sub-render — and not against the component node. That is load-bearing
  * rather than incidental: the component node of a settings screen lives inside its module

--- a/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
@@ -33,6 +33,7 @@
 package org.jahia.modules.serversettings.render;
 
 import org.apache.commons.lang.StringUtils;
+import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
@@ -44,36 +45,51 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
- * Renders a settings component only when the caller holds an administration permission on the resource the
- * request is actually made against.
+ * Renders a settings component from the settings template that declares its access rule, and only for a
+ * caller who holds that rule on the resource the request is made against.
  * <p>
- * The permission requirement belongs on the component, not only on the settings template that normally
- * hosts it ({@code j:requiredPermissionNames}): a component's access rule should travel with the component
- * and hold on every render path, regardless of where the component is placed. This filter makes the
- * requirement a property of the component so it applies uniformly. Because {@code WebflowAction} re-enters
- * the render chain for each webflow POST, it covers every transition too, not just the initial GET.
+ * The access rule of a settings screen is data: the {@code jnt:contentTemplate} that hosts the component
+ * states it in {@code j:requiredPermissionNames} — {@code adminCache} for cache management,
+ * {@code adminSystemInfos} for system information, and so on for each of this module's screens. This
+ * filter reads the rule from there and applies it, so the module's template definitions remain the single
+ * place the requirement is expressed and this filter has nothing to keep in step with them. That also
+ * keeps each screen's own granularity: a screen is rendered for a caller holding the permission that
+ * screen declares, whether that permission is granted directly or through an ancestor permission that
+ * aggregates it.
  * <p>
- * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
- * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings
- * screen lives inside its module ({@code /modules/...}), where a site-scoped administrator holds nothing —
- * measured, {@code site-admin} is {@code false} there and {@code true} on {@code /sites/<key>}. Checking
- * the component node, which is the obvious implementation, would therefore refuse real site administrators.
- * The main resource is the site (site-settings route) or the global settings node (server-administration
- * route), which is what the corresponding administrator role is actually granted on.
+ * Two conditions, both required:
+ * <ol>
+ *   <li>the component renders from a module's template definitions
+ *       ({@code /modules/<module>/<version>/templates/...}), which is where a settings screen is defined;</li>
+ *   <li>the caller holds every permission the nearest declaring template ancestor requires.</li>
+ * </ol>
+ * A component whose ancestors declare no requirement, and a render with no resolvable context resource,
+ * yield an empty fragment. Three of the node types below ({@code jnt:serverSettingsDBSettings},
+ * {@code jnt:serverSettingsMailServerSettings}, {@code jnt:serverSettingsManagePortlets}) are declared in
+ * this module's CND as {@code jmix:studioOnly} and ship neither a view nor a template, so they declare no
+ * requirement and render nothing.
  * <p>
- * Only {@code admin} is accepted, so these screens stay out of reach of an administrator whose authority is
- * scoped to a single site. It is a core permission ({@code root-permissions.xml}) granted by the
- * {@code server-administrator} role; the finer per-screen permissions are contributed by this module's own
- * {@code permissions.xml} and resolve to {@code false} indistinguishably from a denial where they are not
- * registered, which would fail closed for administrators too.
- * The finer per-screen requirement declared on the settings template remains enforced on the administration
- * route, so this filter is an additional condition and never a replacement. Failing to resolve a main resource
- * yields an empty fragment rather than a rendered component.
+ * The permissions are evaluated against the render's <strong>context resource</strong> — the main resource,
+ * or the ajax resource for an ajax sub-render — and not against the component node. That is load-bearing
+ * rather than incidental: the component node of a settings screen lives inside its module
+ * ({@code /modules/...}), where an administrator holds nothing, while the context resource is the global
+ * settings node that the server-administration route resolves, which is what the administrator role is
+ * granted on. Resolving it this way mirrors core's own evaluation of {@code j:requiredPermissionNames}
+ * ({@code TemplatePermissionCheckFilter}), so a screen reached through its administration route resolves
+ * identically here.
+ * <p>
+ * Because {@code WebflowAction} re-enters the render chain for each webflow POST, both conditions cover
+ * every transition and not just the initial GET. In studio, template permissions stay core's business and
+ * this filter applies the placement condition alone, matching how core evaluates
+ * {@code j:requiredPermissionNames} there.
  * <p>
  * Registered via OSGi Declarative Services — no Spring context involvement.
  */
@@ -83,7 +99,7 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
     private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
 
     /** Node types gated by this filter. */
-    private static final String APPLY_ON_NODE_TYPES = 
+    private static final String APPLY_ON_NODE_TYPES =
             "jnt:serverSettingsAboutJahia," +
             "jnt:serverSettingsAdminProperties," +
             "jnt:serverSettingsCacheManagement," +
@@ -96,11 +112,14 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
             "jnt:serverSettingsReportAnIssue," +
             "jnt:serverSettingsSystemInfos";
 
-    /** Any one of these on the main resource is sufficient. */
-    private static final List<String> REQUIRED_PERMISSIONS =
-            Collections.unmodifiableList(Arrays.asList("admin"));
+    /** Where a settings screen is defined: a module's template definitions. */
+    private static final Pattern MODULE_TEMPLATE_PATH = Pattern.compile("^/modules/[^/]+/[^/]+/templates/.+");
 
-    private static final String REQUIRED_PERMISSIONS_LABEL = StringUtils.join(REQUIRED_PERMISSIONS, ", ");
+    /** The mixin a template carries to state an access rule, and the property that holds it. */
+    private static final String DECLARING_TYPE = "jmix:requiredPermissions";
+    private static final String DECLARED_PERMISSIONS = "j:requiredPermissionNames";
+
+    private static final String STUDIO_MODE = "studiomode";
 
     @Activate
     public void activate() {
@@ -113,33 +132,80 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
         // to a caller who lacks the grant.
         setPriority(21.5f);
         setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
-        setDescription("Renders a settings component only for a caller holding an administration permission "
-                + "on the main resource");
+        setDescription("Renders a settings component from its settings template, for a caller holding the "
+                + "permissions that template declares");
         logger.debug("SettingsComponentPermissionFilter active on {}", APPLY_ON_NODE_TYPES);
     }
 
     @Override
     public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        Resource mainResource = renderContext.getMainResource();
-        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
-        if (contextNode == null) {
-            // Fail closed: with no main resource there is nothing to evaluate the permission against, and this
-            // is an administration capability.
-            logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
+        JCRNodeWrapper node = resource.getNode();
+        String nodePath = node.getPath();
+
+        if (!MODULE_TEMPLATE_PATH.matcher(nodePath).matches()) {
+            logger.warn("Not rendering {}: a settings component renders from a module's template definitions",
+                    nodePath);
             return StringUtils.EMPTY;
         }
 
-        for (String permission : REQUIRED_PERMISSIONS) {
-            if (contextNode.hasPermission(permission)) {
-                return null;
+        if (STUDIO_MODE.equals(renderContext.getEditModeConfigName())) {
+            return null;
+        }
+
+        List<String> declared = declaredPermissions(node);
+        if (declared.isEmpty()) {
+            logger.warn("Not rendering {}: no template ancestor declares {}", nodePath, DECLARED_PERMISSIONS);
+            return StringUtils.EMPTY;
+        }
+
+        JCRNodeWrapper contextNode = contextNode(renderContext);
+        if (contextNode == null) {
+            logger.warn("No resource to evaluate {} against; not rendering it", nodePath);
+            return StringUtils.EMPTY;
+        }
+
+        for (String permission : declared) {
+            if (!contextNode.hasPermission(permission)) {
+                if (logger.isWarnEnabled()) {
+                    logger.warn("Not rendering {}: {} does not hold {} on {}", nodePath,
+                            renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                            permission, contextNode.getPath());
+                }
+                return StringUtils.EMPTY;
             }
         }
 
-        if (logger.isWarnEnabled()) {
-            logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
-                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                    REQUIRED_PERMISSIONS_LABEL, contextNode.getPath());
+        return null;
+    }
+
+    /**
+     * The permissions required by the nearest ancestor that declares an access rule, empty when none does.
+     */
+    private static List<String> declaredPermissions(JCRNodeWrapper node) throws RepositoryException {
+        JCRNodeWrapper declaring = node.isNodeType(DECLARING_TYPE)
+                ? node
+                : JCRContentUtils.getParentOfType(node, DECLARING_TYPE);
+        if (declaring == null || !declaring.hasProperty(DECLARED_PERMISSIONS)) {
+            return Collections.emptyList();
         }
-        return StringUtils.EMPTY;
+        List<String> permissions = new ArrayList<>();
+        for (Value value : declaring.getProperty(DECLARED_PERMISSIONS).getValues()) {
+            String permission = value.getString();
+            if (StringUtils.isNotBlank(permission)) {
+                permissions.add(permission);
+            }
+        }
+        return permissions;
+    }
+
+    /**
+     * The resource the access rule is evaluated against: the ajax resource of an ajax sub-render, otherwise
+     * the main resource of the render.
+     */
+    private static JCRNodeWrapper contextNode(RenderContext renderContext) throws RepositoryException {
+        Resource contextResource = renderContext.getAjaxResource() != null
+                ? renderContext.getAjaxResource()
+                : renderContext.getMainResource();
+        return contextResource != null ? contextResource.getNode() : null;
     }
 }

--- a/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
@@ -1,19 +1,4 @@
 /*
- * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/*
  * Wiring note — this is deliberately OSGi Declarative Services, not a Spring bean.
  *
  * Jahia's engineering conventions (the shared `cortex` harness, skill
@@ -202,7 +187,7 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
      * The resource the access rule is evaluated against: the ajax resource of an ajax sub-render, otherwise
      * the main resource of the render.
      */
-    private static JCRNodeWrapper contextNode(RenderContext renderContext) throws RepositoryException {
+    private static JCRNodeWrapper contextNode(RenderContext renderContext) {
         Resource contextResource = renderContext.getAjaxResource() != null
                 ? renderContext.getAjaxResource()
                 : renderContext.getMainResource();

--- a/tests/cypress/e2e/adminPropertiesWriteScope.cy.ts
+++ b/tests/cypress/e2e/adminPropertiesWriteScope.cy.ts
@@ -1,7 +1,7 @@
 // Write scope of the administration-properties screen. The screen edits the root account, and every
 // property it writes carries the same administration requirement, so the requirement holds for the save
-// as a whole. This spec drives the screen's save transition through a component placed on an ordinary
-// page and asserts that the root account only ever changes when the caller administers the server.
+// as a whole. This spec drives the screen's save transition through its administration route and asserts
+// that the root account only ever changes when the caller administers the server.
 //
 // Non-vacuity: the negative assertion is paired with a POSITIVE CONTROL that goes through the exact same
 // request shape and asserts the save DOES land for a server administrator. Without it, a fixture that
@@ -9,16 +9,20 @@
 // the boring reason that nothing was ever driven. The negative case also pins the account to its exact
 // pre-attempt value rather than merely "not the attempted one", which a failed read would satisfy too.
 //
-// The low-privilege account is a real editor of the hosting site, so it can read the page. That makes its
-// refusal a decision about administering the server, and not about being unable to reach the screen.
+// The low-privilege account is proven to be an authenticated session of its own before it is refused, so
+// its refusal is a decision about administering the server and not a failure to hold a session at all.
+// The two callers differ in nothing but what they administer, and they drive the same URL.
 //
 // State is read back THROUGH THE SCREEN, as an administrator, rather than through a content API: the
 // rendered form is populated from the stored root account, so it observes the same state with nothing but
 // the mechanism already under test — no second API surface to be gated or shaped differently.
 //
-// Fully self-contained: creates its own site, the accounts and the placed component in before(); restores
-// the root account and tears everything down in after().
-import { createSite, deleteSite, createUser, deleteUser, grantRoles, addNode } from '@jahia/cypress'
+// A settings component placed outside its settings container is served to no caller at all; that is the
+// invariant of settingsComponentRenderScope.cy.ts and is deliberately not re-asserted here.
+//
+// Fully self-contained: creates its own accounts in before(); restores the root account and tears
+// everything down in after().
+import { createUser, deleteUser, grantRoles } from '@jahia/cypress'
 
 /** What the screen did with a submitted save: was a flow served at all, and did it acknowledge a save. */
 interface SubmitOutcome {
@@ -28,14 +32,12 @@ interface SubmitOutcome {
 
 describe('Administration properties - write scope', () => {
     const uniq = Date.now().toString(36)
-    const site = 'admPropScope' + uniq
 
     const serverAdmin = 'admpropserver' + uniq // administers the server
-    const lowPriv = 'admproplow' + uniq // edits the hosting site, administers nothing
+    const lowPriv = 'admproplow' + uniq // administers nothing
 
-    const placed = 'placedAdminProperties' + uniq
-    const area = `/sites/${site}/home/pagecontent`
-    const componentUrl = `/cms/render/default/en${area}/${placed}.html.ajax`
+    // the screen reached through the administration route that declares its requirement
+    const screenUrl = '/cms/adminframe/default/en/settings.adminProperties.html'
 
     // Captured before anything is driven and put back in after(), so a failing run cannot leave the
     // instance's root account rewritten.
@@ -49,7 +51,7 @@ describe('Administration properties - write scope', () => {
     const render = (user: string) => {
         cy.login(user, 'password')
         return cy
-            .request({ url: componentUrl, qs: { ec: ec() }, failOnStatusCode: false })
+            .request({ url: screenUrl, qs: { ec: ec() }, failOnStatusCode: false })
             .then((res) => (typeof res.body === 'string' ? res.body : ''))
     }
 
@@ -61,9 +63,9 @@ describe('Administration properties - write scope', () => {
             return Cypress.$('<textarea/>').html(field[1]).text()
         })
 
-    // Render the placed component as the given user, then submit its save transition with the supplied
-    // email. Reports whether a flow was served at all and whether the screen acknowledged a save, so a
-    // refused render and a refused save are told apart.
+    // Render the screen as the given user, then submit its save transition with the supplied email.
+    // Reports whether a flow was served at all and whether the screen acknowledged a save, so a refused
+    // render and a refused save are told apart.
     const submitEmail = (user: string, email: string): Cypress.Chainable<SubmitOutcome> =>
         render(user).then((body) => {
             const action = /<form[^>]*id="adminProperties"[^>]*action="([^"]+)"/.exec(body)
@@ -95,18 +97,11 @@ describe('Administration properties - write scope', () => {
 
     before(() => {
         cy.login()
-        createSite(site, { languages: 'en', templateSet: 'templates-system', serverName: 'localhost', locale: 'en' })
 
         createUser(serverAdmin, 'password')
         createUser(lowPriv, 'password')
 
         grantRoles('/', ['server-administrator'], serverAdmin, 'USER')
-        // both accounts must be able to read the hosting page, so a refusal is never just an unreadable node
-        grantRoles(`/sites/${site}`, ['editor'], serverAdmin, 'USER')
-        grantRoles(`/sites/${site}`, ['editor'], lowPriv, 'USER')
-
-        addNode({ parentPathOrId: `/sites/${site}/home`, primaryNodeType: 'jnt:contentList', name: 'pagecontent' })
-        addNode({ parentPathOrId: area, primaryNodeType: 'jnt:serverSettingsAdminProperties', name: placed })
 
         storedEmail(serverAdmin).then((value) => {
             originalEmail = value
@@ -119,7 +114,6 @@ describe('Administration properties - write scope', () => {
         cy.login()
         deleteUser(serverAdmin)
         deleteUser(lowPriv)
-        deleteSite(site)
     })
 
     it('lets a server administrator save the root account (positive control)', () => {
@@ -132,6 +126,18 @@ describe('Administration properties - write scope', () => {
     })
 
     it('does not let a caller that administers nothing rewrite the root account', () => {
+        cy.login(lowPriv, 'password')
+        cy.request({
+            method: 'POST',
+            url: '/modules/graphql',
+            headers: { Origin: Cypress.config().baseUrl as string },
+            body: { query: '{currentUser{name}}' },
+        }).then((res) => {
+            expect(res.body?.data?.currentUser?.name, 'the refused caller must hold a session of its own').to.eq(
+                lowPriv,
+            )
+        })
+
         const email = `admprop-attempt-${uniq}@jahia.invalid`
         storedEmail(serverAdmin).then((before) => {
             submitEmail(lowPriv, email).then((result) => {

--- a/tests/cypress/e2e/adminPropertiesWriteScope.cy.ts
+++ b/tests/cypress/e2e/adminPropertiesWriteScope.cy.ts
@@ -9,9 +9,11 @@
 // the boring reason that nothing was ever driven. The negative case also pins the account to its exact
 // pre-attempt value rather than merely "not the attempted one", which a failed read would satisfy too.
 //
-// The low-privilege account is proven to be an authenticated session of its own before it is refused, so
-// its refusal is a decision about administering the server and not a failure to hold a session at all.
-// The two callers differ in nothing but what they administer, and they drive the same URL.
+// The low-privilege account is a real editor of a throwaway site, which is what makes it an ordinary
+// authenticated account rather than one that holds nothing at all, and it proves that session through
+// currentUser before being refused. So its refusal is a decision about administering the server, not a
+// failure to hold a session. The two callers differ in nothing but what they administer, and they drive
+// the same URL.
 //
 // State is read back THROUGH THE SCREEN, as an administrator, rather than through a content API: the
 // rendered form is populated from the stored root account, so it observes the same state with nothing but
@@ -20,9 +22,9 @@
 // A settings component placed outside its settings container is served to no caller at all; that is the
 // invariant of settingsComponentRenderScope.cy.ts and is deliberately not re-asserted here.
 //
-// Fully self-contained: creates its own accounts in before(); restores the root account and tears
-// everything down in after().
-import { createUser, deleteUser, grantRoles } from '@jahia/cypress'
+// Fully self-contained: creates its own site and accounts in before(); restores the root account and
+// tears everything down in after().
+import { createSite, deleteSite, createUser, deleteUser, grantRoles } from '@jahia/cypress'
 
 /** What the screen did with a submitted save: was a flow served at all, and did it acknowledge a save. */
 interface SubmitOutcome {
@@ -32,9 +34,10 @@ interface SubmitOutcome {
 
 describe('Administration properties - write scope', () => {
     const uniq = Date.now().toString(36)
+    const site = 'admPropScope' + uniq
 
     const serverAdmin = 'admpropserver' + uniq // administers the server
-    const lowPriv = 'admproplow' + uniq // administers nothing
+    const lowPriv = 'admproplow' + uniq // edits the throwaway site, administers nothing
 
     // the screen reached through the administration route that declares its requirement
     const screenUrl = '/cms/adminframe/default/en/settings.adminProperties.html'
@@ -97,11 +100,15 @@ describe('Administration properties - write scope', () => {
 
     before(() => {
         cy.login()
+        createSite(site, { languages: 'en', templateSet: 'templates-system', serverName: 'localhost', locale: 'en' })
 
         createUser(serverAdmin, 'password')
         createUser(lowPriv, 'password')
 
         grantRoles('/', ['server-administrator'], serverAdmin, 'USER')
+        // an ordinary grant, so the refused caller is a real authenticated account and not one holding
+        // nothing at all — the session it proves below is what makes its refusal about authority
+        grantRoles(`/sites/${site}`, ['editor'], lowPriv, 'USER')
 
         storedEmail(serverAdmin).then((value) => {
             originalEmail = value
@@ -114,6 +121,7 @@ describe('Administration properties - write scope', () => {
         cy.login()
         deleteUser(serverAdmin)
         deleteUser(lowPriv)
+        deleteSite(site)
     })
 
     it('lets a server administrator save the root account (positive control)', () => {

--- a/tests/cypress/e2e/settingsComponentRenderScope.cy.ts
+++ b/tests/cypress/e2e/settingsComponentRenderScope.cy.ts
@@ -1,45 +1,70 @@
-// Render scope of the server settings components. A component's access rule should travel with the
-// component and hold on every render path, regardless of where the component is placed — not only on the
-// settings template that normally hosts it. This spec renders one of these components through an ordinary
-// resource and asserts that its web flow remains available only to a caller holding server administration,
-// and in particular NOT to a site administrator, whose authority stops at one site.
+// Render scope of the server settings components. A settings component renders from the settings template
+// that declares its access rule, for a caller who holds that rule on the resource the request is made
+// against. This spec asserts both halves: the flow of a component placed in an ordinary content area is
+// served to no caller, and the flow of the same screen reached through its administration route is served
+// to the administrators the template's own requirement names — including a role that names that requirement
+// directly rather than through an ancestor permission.
 //
-// Non-vacuity: the negative assertions are paired with a POSITIVE CONTROL that goes through the exact
-// same request shape and asserts the flow IS served to a server administrator, so a fixture that
-// renders nothing cannot produce a false green. The site-administrator case doubles as a sharper
-// control: that account is a real administrator of the hosting site and can read the page, so its
-// refusal isolates the requirement to server administration rather than to "being logged in" or
-// "being some kind of administrator".
+// Non-vacuity: the negative assertions and the positive control go through the same detector and the same
+// request shape, so a fixture that renders nothing cannot produce a false green. The site-administrator case
+// is the sharper negative: that account is a real administrator of the hosting site and can read the page,
+// so its refusal isolates the requirement to server administration rather than to "being logged in" or
+// "being some kind of administrator". The screen-scoped role asserts its own grants through hasPermission
+// before rendering anything, so that test measures the render condition and not a mis-built fixture.
 //
-// Fully self-contained: creates its own site, the accounts and the placed component in before();
-// tears everything down in after().
-import { createSite, deleteSite, createUser, deleteUser, grantRoles, addNode } from '@jahia/cypress'
+// Fully self-contained: creates its own site, the accounts, the screen-scoped role and the placed component
+// in before(); tears everything down in after().
+import { createSite, deleteSite, createUser, deleteUser, grantRoles, addNode, deleteNode } from '@jahia/cypress'
 
 describe('Server settings components - render scope', () => {
     const uniq = Date.now().toString(36)
     const site = 'srvRenderScope' + uniq
 
     const serverAdmin = 'srvscopeserver' + uniq // server administration, granted at the repository root
+    const scopedAdmin = 'srvscopescoped' + uniq // administers one screen of the server
     const siteAdmin = 'srvscopesite' + uniq // administers the hosting site only
     const lowPriv = 'srvscopelow' + uniq // ordinary account, administers nothing
 
+    // A server-administration role that names the cache screen's own permission directly, alongside what any
+    // server administrator needs to reach the administration route. It deliberately does NOT name the ancestor
+    // permission that aggregates the per-screen ones, which is what makes it the case a per-screen requirement
+    // has to keep working for.
+    const scopedRole = 'srvscopecacheonly' + uniq
+    const scopedRolePermissions = ['administrationAccess', 'adminCache', 'repository-permissions', 'publish']
+
     const placed = 'placedCacheManagement' + uniq
     const area = `/sites/${site}/home/pagecontent`
+    // the page that hosts it — this is the URL that gets rendered
     const pageUrl = `/cms/render/default/en/sites/${site}/home.html`
+    // the same screen reached through the administration route that declares its requirement
+    const settingsUrl = '/cms/adminframe/default/en/settings.cacheManagement.html'
 
     before(() => {
         cy.login()
         createSite(site, { languages: 'en', templateSet: 'templates-system', serverName: 'localhost', locale: 'en' })
 
         createUser(serverAdmin, 'password')
+        createUser(scopedAdmin, 'password')
         createUser(siteAdmin, 'password')
         createUser(lowPriv, 'password')
 
+        addNode({
+            parentPathOrId: '/roles',
+            primaryNodeType: 'jnt:role',
+            name: scopedRole,
+            properties: [
+                { name: 'j:roleGroup', value: 'server-role' },
+                { name: 'j:privilegedAccess', value: 'true' },
+                { name: 'j:permissionNames', values: scopedRolePermissions },
+            ],
+        })
+
         grantRoles('/', ['server-administrator'], serverAdmin, 'USER')
+        grantRoles('/', [scopedRole], scopedAdmin, 'USER')
         grantRoles(`/sites/${site}`, ['site-administrator'], siteAdmin, 'USER')
         grantRoles(`/sites/${site}`, ['editor'], lowPriv, 'USER')
 
-        // the server administrator must also be able to read the hosting site, so the positive control
+        // the server administrator must also be able to read the hosting site, so the off-route case
         // measures the component and not the site's read ACL
         grantRoles(`/sites/${site}`, ['editor'], serverAdmin, 'USER')
 
@@ -50,41 +75,77 @@ describe('Server settings components - render scope', () => {
     after(() => {
         cy.login()
         deleteUser(serverAdmin)
+        deleteUser(scopedAdmin)
         deleteUser(siteAdmin)
         deleteUser(lowPriv)
+        deleteNode(`/roles/${scopedRole}`)
         deleteSite(site)
     })
 
-    // Render the hosting page as whoever is logged in and report how many flow execution keys were
-    // served. Without one there is no flow to drive.
-    const flowsServed = (user: string) => {
+    // Render a URL as whoever is logged in and report how many flow execution keys were served. Without one
+    // there is no flow to drive.
+    const flowsServed = (user: string, url: string) => {
         cy.login(user, 'password')
         return cy
-            .request({ url: pageUrl, failOnStatusCode: false, qs: { ec: uniq + Math.floor(Math.random() * 1e6) } })
+            .request({ url, failOnStatusCode: false, qs: { ec: uniq + Math.floor(Math.random() * 1e6) } })
             .then((res) => {
                 const body = typeof res.body === 'string' ? res.body : ''
                 return { status: res.status, served: (body.match(/webflowexecution/g) || []).length }
             })
     }
 
-    it('serves the flow of the placed component to a server administrator (positive control)', () => {
-        flowsServed(serverAdmin).then(({ status, served }) => {
+    const holdsPermission = (path: string, permission: string) =>
+        cy
+            .request({
+                method: 'POST',
+                url: '/modules/graphql',
+                headers: { Origin: Cypress.config().baseUrl as string },
+                body: {
+                    query: `{jcr(workspace:EDIT){nodeByPath(path:"${path}"){hasPermission(permissionName:"${permission}")}}}`,
+                },
+            })
+            .then((res) => res.body?.data?.jcr?.nodeByPath?.hasPermission as boolean)
+
+    it('serves the screen on its administration route to a server administrator (positive control)', () => {
+        flowsServed(serverAdmin, settingsUrl).then(({ served }) => {
+            expect(
+                served,
+                'the server administrator must be served the flow on the administration route',
+            ).to.be.greaterThan(0)
+        })
+    })
+
+    it('serves the screen on its administration route to a role naming that screen only', () => {
+        cy.login(scopedAdmin, 'password')
+        holdsPermission('/settings', 'adminCache').then((held) => {
+            expect(held, 'the fixture role must grant the cache screen its own permission').to.be.true
+        })
+        holdsPermission('/settings', 'admin').then((held) => {
+            expect(held, 'the fixture role must not grant the ancestor permission').to.be.false
+        })
+        flowsServed(scopedAdmin, settingsUrl).then(({ served }) => {
+            expect(served, 'a role naming the screen must be served that screen').to.be.greaterThan(0)
+        })
+    })
+
+    it('serves the placed component to no server administrator', () => {
+        flowsServed(serverAdmin, pageUrl).then(({ status, served }) => {
             expect(status, 'the server administrator must be able to read the hosting page').to.eq(200)
-            expect(served, 'the server administrator must still be served the flow').to.be.greaterThan(0)
+            expect(served, 'no flow may be served from an ordinary content area').to.eq(0)
         })
     })
 
-    it('does not serve the flow to an administrator of the hosting site only', () => {
-        flowsServed(siteAdmin).then(({ status, served }) => {
+    it('serves the placed component to no administrator of the hosting site', () => {
+        flowsServed(siteAdmin, pageUrl).then(({ status, served }) => {
             expect(status, 'the site administrator must be able to read the hosting page').to.eq(200)
-            expect(served, 'a site administrator must not be served a server administration flow').to.eq(0)
+            expect(served, 'no flow may be served from an ordinary content area').to.eq(0)
         })
     })
 
-    it('does not serve the flow to a caller that administers nothing', () => {
-        flowsServed(lowPriv).then(({ status, served }) => {
+    it('serves the placed component to no caller that administers nothing', () => {
+        flowsServed(lowPriv, pageUrl).then(({ status, served }) => {
             expect(status, 'the low-privilege account must be able to read the hosting page').to.eq(200)
-            expect(served, 'no flow may be served to a caller that administers nothing').to.eq(0)
+            expect(served, 'no flow may be served from an ordinary content area').to.eq(0)
         })
     })
 })


### PR DESCRIPTION
## Summary

A server settings screen renders from the settings template that declares its access rule, for a caller who holds that rule on the resource the request is made against.

The rule stays where this module already states it — the hosting `jnt:contentTemplate`'s `j:requiredPermissionNames` — so the template definitions remain the single place a screen's requirement is expressed, and each screen keeps its own granularity: a caller is served a screen when they hold the permission that screen names, whether that permission was granted directly or through an ancestor permission that aggregates it.

Every renderable screen in this module already declares one, so no template data changes here:

| Screen | Declares |
|---|---|
| About Jahia | `administrationAccess` |
| Web projects | `adminVirtualSites` |
| Administration properties | `adminRootUser` |
| Password policy | `adminPasswordPolicy` |
| System information | `adminSystemInfos` |
| Cache management | `adminCache` |
| Manage memory | `adminManageMemory` |
| Report an issue | `adminIssueTracking` |

`jnt:serverSettingsDBSettings`, `jnt:serverSettingsMailServerSettings` and `jnt:serverSettingsManagePortlets` stay in the filter's node-type set. They are declared in this module's CND as `jmix:studioOnly` and ship neither a view nor a template, so they declare no requirement and render nothing.

## Change

**`SettingsComponentPermissionFilter`** applies two conditions on the node types it covers:

1. the component renders from a module's template definitions (`/modules/<module>/<version>/templates/...`), which is where a settings screen is defined;
2. the caller holds every permission the nearest declaring template ancestor requires, evaluated against the render's context resource — the ajax resource of an ajax sub-render, otherwise the main resource. That is the same resolution core applies to `j:requiredPermissionNames` in `TemplatePermissionCheckFilter`, so a screen reached through its administration route resolves identically here.

A component whose ancestors declare no requirement, and a render with no resolvable context resource, yield an empty fragment, and the path is logged at WARN. In studio, template permissions stay core's business and this filter applies the placement condition alone, matching how core evaluates `j:requiredPermissionNames` there. The filter keeps its slot at priority 21.5 and its node-type set unchanged.

Worth a reviewer's eye: the filter adds no strictness of its own beyond what each template declares. About Jahia declares `administrationAccess`, so that screen is served to a caller holding it — which is what core's own evaluation of that template already does on the administration route.

**`settingsComponentRenderScope.cy.ts`** asserts both halves of the invariant:

- the flow of a component placed in an ordinary content area is served to no caller — server administrator, administrator of the hosting site, or an account that administers nothing;
- the flow of the same screen reached through its administration route is served to the server administrator;
- a server-administration role that names a single screen's permission directly (`administrationAccess` + `adminCache`, without the ancestor permission) is served that screen. That test asserts its own fixture through `hasPermission` on `/settings` first — the role holds `adminCache` and not `admin` — so it measures the render condition rather than a mis-built role.

## Verification

- `mvn compile` clean (JDK 11).
- `prettier --check` clean against the version this module pins (`^2.6.2`); `eslint` enforces prettier through `plugin:prettier/recommended`, and the rest of the eslint pass runs in CI.
- The Cypress spec is authored but not executed locally — no lab was stood up for this change, so CI is the gate. The fixture worth watching is the `jnt:role` created under `/roles` with `j:privilegedAccess`, granted at the repository root.

## Changelog

The pending fragment from the change this builds on describes the same behaviour, so it is **amended in place** rather than joined by a second entry — two fragments would put two entries for one behaviour in the same release notes, the earlier of them describing behaviour that never shipped.
