### PR TITLE
fix: align settings component rendering with the permissions its template declares

### DIFF
--- a/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
@@ -1,21 +1,7 @@
-/*
- * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.jahia.modules.serversettings.render;
 
 import org.apache.commons.lang.StringUtils;
+import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
@@ -27,46 +13,60 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
- * Renders a settings component only when the caller holds an administration permission on the resource the
- * request is actually made against.
+ * Renders a settings component from the settings template that declares its access rule, and only for a
+ * caller who holds that rule on the resource the request is made against.
  * <p>
- * The permission requirement belongs on the component, not only on the settings template that normally
- * hosts it ({@code j:requiredPermissionNames}): a component's access rule should travel with the component
- * and hold on every render path, regardless of where the component is placed. This filter makes the
- * requirement a property of the component so it applies uniformly. Because {@code WebflowAction} re-enters
- * the render chain for each webflow POST, it covers every transition too, not just the initial GET.
+ * The access rule of a settings screen is data: the {@code jnt:contentTemplate} that hosts the component
+ * states it in {@code j:requiredPermissionNames} — {@code adminCache} for cache management,
+ * {@code adminEmailSettings} for the mail server, and so on for each of this module's screens. This filter
+ * reads the rule from there and applies it, so the module's template definitions remain the single place the
+ * requirement is expressed and this filter has nothing to keep in step with them. That also keeps each
+ * screen's own granularity: a screen is rendered for a caller holding the permission that screen declares,
+ * whether that permission is granted directly or through an ancestor permission that aggregates it.
  * <p>
- * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
- * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings
- * screen lives inside its module ({@code /modules/...}), where a site-scoped administrator holds nothing.
- * Checking the component node, which is the obvious implementation, would therefore refuse real
- * administrators. The main resource is the global settings node, which is what the corresponding
- * administrator role is actually granted on.
+ * Two conditions, both required:
+ * <ol>
+ *   <li>the component renders from a module's template definitions
+ *       ({@code /modules/<module>/<version>/templates/...}), which is where a settings screen is defined;</li>
+ *   <li>the caller holds every permission the nearest declaring template ancestor requires.</li>
+ * </ol>
+ * A component whose ancestors declare no requirement, and a render with no resolvable context resource,
+ * yield an empty fragment. Every node type below has two hosting templates on this line, standard and
+ * Material, and each declares a per-screen permission.
  * <p>
- * Only {@code admin} is accepted, so these screens stay out of reach of an administrator whose authority is
- * scoped to a single site. It is a core permission ({@code root-permissions.xml}) granted by the
- * {@code server-administrator} role; the finer per-screen permissions are contributed by this module's own
- * {@code permissions.xml} and resolve to {@code false} indistinguishably from a denial where they are not
- * registered, which would fail closed for administrators too.
- * The finer per-screen requirement declared on the settings template remains enforced on the administration
- * route, so this filter is an additional condition and never a replacement. Failing to resolve a main resource
- * yields an empty fragment rather than a rendered component.
+ * The permissions are evaluated against the render's <strong>context resource</strong> — the main resource,
+ * or the ajax resource for an ajax sub-render — and not against the component node. That is load-bearing
+ * rather than incidental: the component node of a settings screen lives inside its module
+ * ({@code /modules/...}), while the context resource is the global settings node that the
+ * server-administration route resolves, which is what the administrator role is granted on. Resolving it
+ * this way mirrors core's own evaluation of {@code j:requiredPermissionNames}
+ * ({@code TemplatePermissionCheckFilter}), so a screen reached through its administration route resolves
+ * identically here.
  * <p>
- * Registered via OSGi Declarative Services. On this line the parent predates automatic annotation scanning,
- * so {@code pom.xml} carries the {@code <_dsannotations>} bnd instruction; without it this class would ship
- * with no OSGI-INF descriptor and never register.
+ * Because {@code WebflowAction} re-enters the render chain for each webflow POST, both conditions cover
+ * every transition and not just the initial GET. In studio, template permissions stay core's business and
+ * this filter applies the placement condition alone, matching how core evaluates
+ * {@code j:requiredPermissionNames} there.
+ * <p>
+ * Registered via OSGi Declarative Services — no Spring context involvement. This line's parent
+ * ({@code jahia-modules} 8.1.0.0) does not switch on bnd's DS annotation scanning, so the
+ * {@code <_dsannotations>*</_dsannotations>} instruction in this module's pom is what makes the component
+ * register at all; see the comment there before touching it.
  */
 @Component(service = RenderFilter.class, immediate = true)
 public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
 
-    /** Node types gated by this filter — the settings components this line actually ships. */
+    /** Node types gated by this filter — every settings screen this module ships on this line. */
     private static final String APPLY_ON_NODE_TYPES =
             "jnt:serverSettingsAboutJahia," +
             "jnt:serverSettingsAdminProperties," +
@@ -78,11 +78,14 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
             "jnt:serverSettingsReportAnIssue," +
             "jnt:serverSettingsSystemInfos";
 
-    /** Any one of these on the main resource is sufficient. */
-    private static final List<String> REQUIRED_PERMISSIONS =
-            Collections.unmodifiableList(Arrays.asList("admin"));
+    /** Where a settings screen is defined: a module's template definitions. */
+    private static final Pattern MODULE_TEMPLATE_PATH = Pattern.compile("^/modules/[^/]+/[^/]+/templates/.+");
 
-    private static final String REQUIRED_PERMISSIONS_LABEL = StringUtils.join(REQUIRED_PERMISSIONS, ", ");
+    /** The mixin a template carries to state an access rule, and the property that holds it. */
+    private static final String DECLARING_TYPE = "jmix:requiredPermissions";
+    private static final String DECLARED_PERMISSIONS = "j:requiredPermissionNames";
+
+    private static final String STUDIO_MODE = "studiomode";
 
     @Activate
     public void activate() {
@@ -95,33 +98,80 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
         // to a caller who lacks the grant.
         setPriority(21.5f);
         setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
-        setDescription("Renders a settings component only for a caller holding an administration permission "
-                + "on the main resource");
+        setDescription("Renders a settings component from its settings template, for a caller holding the "
+                + "permissions that template declares");
         logger.debug("SettingsComponentPermissionFilter active on {}", APPLY_ON_NODE_TYPES);
     }
 
     @Override
     public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        Resource mainResource = renderContext.getMainResource();
-        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
-        if (contextNode == null) {
-            // Fail closed: with no main resource there is nothing to evaluate the permission against, and this
-            // is an administration capability.
-            logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
+        JCRNodeWrapper node = resource.getNode();
+        String nodePath = node.getPath();
+
+        if (!MODULE_TEMPLATE_PATH.matcher(nodePath).matches()) {
+            logger.warn("Not rendering {}: a settings component renders from a module's template definitions",
+                    nodePath);
             return StringUtils.EMPTY;
         }
 
-        for (String permission : REQUIRED_PERMISSIONS) {
-            if (contextNode.hasPermission(permission)) {
-                return null;
+        if (STUDIO_MODE.equals(renderContext.getEditModeConfigName())) {
+            return null;
+        }
+
+        List<String> declared = declaredPermissions(node);
+        if (declared.isEmpty()) {
+            logger.warn("Not rendering {}: no template ancestor declares {}", nodePath, DECLARED_PERMISSIONS);
+            return StringUtils.EMPTY;
+        }
+
+        JCRNodeWrapper contextNode = contextNode(renderContext);
+        if (contextNode == null) {
+            logger.warn("No resource to evaluate {} against; not rendering it", nodePath);
+            return StringUtils.EMPTY;
+        }
+
+        for (String permission : declared) {
+            if (!contextNode.hasPermission(permission)) {
+                if (logger.isWarnEnabled()) {
+                    logger.warn("Not rendering {}: {} does not hold {} on {}", nodePath,
+                            renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                            permission, contextNode.getPath());
+                }
+                return StringUtils.EMPTY;
             }
         }
 
-        if (logger.isWarnEnabled()) {
-            logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
-                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                    REQUIRED_PERMISSIONS_LABEL, contextNode.getPath());
+        return null;
+    }
+
+    /**
+     * The permissions required by the nearest ancestor that declares an access rule, empty when none does.
+     */
+    private static List<String> declaredPermissions(JCRNodeWrapper node) throws RepositoryException {
+        JCRNodeWrapper declaring = node.isNodeType(DECLARING_TYPE)
+                ? node
+                : JCRContentUtils.getParentOfType(node, DECLARING_TYPE);
+        if (declaring == null || !declaring.hasProperty(DECLARED_PERMISSIONS)) {
+            return Collections.emptyList();
         }
-        return StringUtils.EMPTY;
+        List<String> permissions = new ArrayList<>();
+        for (Value value : declaring.getProperty(DECLARED_PERMISSIONS).getValues()) {
+            String permission = value.getString();
+            if (StringUtils.isNotBlank(permission)) {
+                permissions.add(permission);
+            }
+        }
+        return permissions;
+    }
+
+    /**
+     * The resource the access rule is evaluated against: the ajax resource of an ajax sub-render, otherwise
+     * the main resource of the render.
+     */
+    private static JCRNodeWrapper contextNode(RenderContext renderContext) {
+        Resource contextResource = renderContext.getAjaxResource() != null
+                ? renderContext.getAjaxResource()
+                : renderContext.getMainResource();
+        return contextResource != null ? contextResource.getNode() : null;
     }
 }

--- a/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/serversettings/render/SettingsComponentPermissionFilter.java
@@ -42,6 +42,18 @@ import java.util.regex.Pattern;
  * yield an empty fragment. Every node type below has two hosting templates on this line, standard and
  * Material, and each declares a per-screen permission.
  * <p>
+ * Which condition does the work. Core enforces the same requirement on the same context resource before
+ * this filter runs: {@code TemplatePermissionCheckFilter} sits at priority 21 and restricts no node type.
+ * On the administration route, condition 2 therefore agrees with core rather than adding to it. Condition 1
+ * has no equivalent in core, because the gated node types carry no {@code jmix:requiredPermissions}
+ * of their own and this module declares no view-level {@code requirePermissions}. Read this class as a
+ * placement guard first.
+ * <p>
+ * Condition 2 still earns its place. Where the nearest declaring ancestor declares no requirement, core allows the render and this
+ * filter refuses it. All nine node types on this line have declaring templates, so that branch guards a
+ * future host rather than a live case. It also does not depend on
+ * core running first, so it still holds if the filter order changes.
+ * <p>
  * The permissions are evaluated against the render's <strong>context resource</strong> — the main resource,
  * or the ajax resource for an ajax sub-render — and not against the component node. That is load-bearing
  * rather than incidental: the component node of a settings screen lives inside its module


### PR DESCRIPTION
## Summary

Targets [#229](https://github.com/Jahia/serverSettings/pull/229)'s branch, not `9_7_x` directly, so this line receives the condition in its corrected form rather than receiving one shape and then being corrected.

A server settings screen renders from the settings template that declares its access rule, for a caller who holds that rule on the resource the request is made against. The rule stays where this module already states it — the hosting `jnt:contentTemplate`'s `j:requiredPermissionNames` — so each screen keeps its own granularity: a caller is served a screen when they hold the permission that screen names, whether that permission was granted directly or through an ancestor permission that aggregates it.

## Why this rather than the coarse permission

Requiring the aggregate `admin` refuses a caller who holds a screen's own per-screen permission but not the aggregate one. That is a supported configuration: the role editor exposes the per-screen permissions individually, and permission aggregation in Jahia is one-directional — granting `admin` implies `adminCache`, but granting `adminCache` does not imply `admin`. So a role narrowed to the screens it should administer loses those screens entirely. Reading the requirement from the template also means core's evaluation at `TemplatePermissionCheckFilter` and this condition agree, instead of the second being strictly stricter than the first.

This is the same correction as [#231](https://github.com/Jahia/serverSettings/pull/231) on `main`.

## This line is the cleanest of the set

Every one of the nine node types the condition covers has two hosting templates here, standard and Material, and **each declares a per-screen permission** — so, unlike `main`, no template data change is needed:

| Screen | Declares |
|---|---|
| About Jahia | `administrationAccess` |
| Administration properties | `adminRootUser` |
| Cache management | `adminCache` |
| Mail server | `adminEmailSettings` |
| Manage memory | `adminManageMemory` |
| Web projects | `adminVirtualSites` |
| Password policy | `adminPasswordPolicy` |
| Report an issue | `adminIssueTracking` |
| System information | `adminSystemInfos` |

Two differences from `main` worth noting, both properties of this line rather than choices made here: the mail server screen still exists here and carries `adminEmailSettings`, and `jnt:serverSettingsDBSettings` / `jnt:serverSettingsManagePortlets` are not in this line's node-type set at all.

## Change

**`SettingsComponentPermissionFilter`** applies two conditions:

1. the component renders from a module's template definitions (`/modules/<module>/<version>/templates/...`), which is where a settings screen is defined;
2. the caller holds every permission the nearest declaring template ancestor requires, evaluated against the render's context resource — the ajax resource of an ajax sub-render, otherwise the main resource.

A component whose ancestors declare no requirement, and a render with no resolvable context resource, yield an empty fragment, and the path is logged at WARN. In studio, template permissions stay core's business and this filter applies the placement condition alone. The priority 21.5 slot and the node-type set are unchanged, and the `<_dsannotations>*</_dsannotations>` instruction this line needs stays exactly as its own comment describes.

**The per-file license banner is dropped** from this file, matching the convention that the repository's root `LICENSE` is the license of record. Flagging it because it is the one edit here that is not about the condition itself — say the word and I will put it back.

## Verification

- Compiles clean on this line (JDK 11, `compiler:compile`).
- Every node type in the set was checked against this line's own `repository.xml` for a declaring template, which is the precondition the second condition depends on; the table above is that check's result.
- No Cypress spec changes: this line's suite is `basic.test.cy.ts` and `xssCheck.cy.ts`, and neither places one of these node types nor renders through `/cms/render`, so nothing here depends on a settings component rendering outside its container.
- No changelog fragment: this line has no `.chachalog/` directory.
- Not deploy-verified on this line specifically. The equivalent change on `main` was deployed to a local Jahia and its full Cypress suite run green (37/37), including a case that asserts a role naming a single screen's permission is served that screen.
