### PR TITLE
fix: state each server settings screen's permission requirement on the screen itself

### DIFF
--- a/.chachalog/UYVyGNjr.md
+++ b/.chachalog/UYVyGNjr.md
@@ -1,0 +1,5 @@
+---
+serverSettings: patch
+---
+
+Changed the system information and About screens so they are shown only to callers holding the permission each screen requires.

--- a/src/main/resources/jnt_serverSettingsAboutJahia/html/serverSettingsAboutJahia.properties
+++ b/src/main/resources/jnt_serverSettingsAboutJahia/html/serverSettingsAboutJahia.properties
@@ -1,0 +1,6 @@
+# See the note on jnt_serverSettingsSystemInfos: the requirement belongs on the component so it holds on
+# every render path, and `administrationAccess` is what this screen's own hosting template declares
+# (`j:requiredPermissionNames` in repository.xml). It is registered as a child of the core `admin`
+# permission in this module's `permissions.xml`, so it is granted at the repository root and resolves
+# wherever this screen can render.
+requirePermissions=administrationAccess

--- a/src/main/resources/jnt_serverSettingsSystemInfos/html/serverSettingsSystemInfos.properties
+++ b/src/main/resources/jnt_serverSettingsSystemInfos/html/serverSettingsSystemInfos.properties
@@ -1,0 +1,12 @@
+# The permission requirement belongs on the component, not only on the settings template that normally
+# hosts it: a component's access rule should travel with the component and hold on every render path,
+# regardless of where it is placed. `TemplatePermissionCheckFilter` enforces this before the view runs,
+# and it propagates to every view variant via the default view's properties.
+#
+# `adminSystemInfos` is what this screen's own hosting template declares
+# (`j:requiredPermissionNames` in repository.xml), so the component and the template state the same
+# requirement. This module's `permissions.xml` registers it as a child of the core `admin` permission,
+# which the server-administrator role is granted at the repository root — so it resolves wherever this
+# screen can render. A site-scoped permission would not: it is held on a site, and this component's own
+# node lives under /modules, where a site administrator holds nothing.
+requirePermissions=adminSystemInfos

--- a/tests/cypress/e2e/settingsScreenRenderScope.cy.ts
+++ b/tests/cypress/e2e/settingsScreenRenderScope.cy.ts
@@ -1,0 +1,124 @@
+// Render scope of the system information and About screens. Each of these screens states the permission
+// it requires next to its own default view, so the requirement travels with the screen and holds on every
+// render path, not only on the settings template that normally hosts it. This spec places each screen in
+// an ordinary page area — a render path that does not go through that template — and asserts the screen is
+// served only to a caller holding server administration.
+//
+// Non-vacuity: every negative assertion is paired with a POSITIVE CONTROL that goes through the exact same
+// request shape and asserts the screen IS served to a server administrator. Without it, a fixture that
+// renders nothing at all would produce a false green — the screen would be absent for the boring reason
+// that it was never reachable. The control asserts a marker that only the screen itself can emit, and the
+// negatives assert an empty fragment, which is stronger than "the marker is missing".
+//
+// The site administrator is the sharper of the two refusals: that account really does administer the
+// hosting site, so its refusal isolates the requirement to server administration rather than to "being
+// logged in" or "being some kind of administrator". It holds `site-admin`, which is a different permission
+// branch from the `admin` these two screens require.
+//
+// Each screen is requested as its own resource rather than through the surrounding page, so the assertion
+// reads the fragment the requirement governs and does not depend on what else the page template renders.
+//
+// Fully self-contained: creates its own site, the accounts and the placed screens in before(); tears
+// everything down in after().
+import { createSite, deleteSite, createUser, deleteUser, grantRoles, addNode } from '@jahia/cypress'
+
+/** A screen under test, and a marker only that screen's own view can emit. */
+interface Screen {
+    label: string
+    nodeType: string
+    /** Present in the served fragment; nothing else on this instance emits it. */
+    marker: string
+}
+
+const screens: Screen[] = [
+    // the screen lists the JVM's system properties, and every JVM defines java.vendor
+    { label: 'system information', nodeType: 'jnt:serverSettingsSystemInfos', marker: 'java.vendor' },
+    // the licence pane of the About screen
+    { label: 'About', nodeType: 'jnt:serverSettingsAboutJahia', marker: 'id="jahiaLicense"' },
+]
+
+describe('Server settings screens - render scope', () => {
+    const uniq = Date.now().toString(36)
+    const site = 'srvScreenScope' + uniq
+
+    const serverAdmin = 'srvscreenserver' + uniq // administers the server, granted at the repository root
+    const siteAdmin = 'srvscreensite' + uniq // administers the hosting site only
+    const lowPriv = 'srvscreenlow' + uniq // edits the hosting site, administers nothing
+
+    const area = `/sites/${site}/home/pagecontent`
+    const placedName = (screen: Screen) => screen.nodeType.replace('jnt:', 'placed') + uniq
+
+    // Every render gets its own cache-buster: a repeated one would let the fragment cache answer, and a
+    // fragment cached for another caller reads exactly like a decision this spec never made.
+    let probe = 0
+    const ec = () => `${uniq}-${probe++}`
+
+    /** Render one placed screen as the given caller and report the fragment it was served. */
+    const fragment = (user: string, screen: Screen) => {
+        cy.login(user, 'password')
+        return cy
+            .request({
+                url: `/cms/render/default/en${area}/${placedName(screen)}.html.ajax`,
+                qs: { ec: ec() },
+                failOnStatusCode: false,
+            })
+            .then((res) => {
+                // every caller here can read the placed node, so a refusal is always an empty fragment and
+                // never an unreadable node
+                expect(res.status, `${user} must be able to read the placed screen`).to.eq(200)
+                return typeof res.body === 'string' ? res.body : ''
+            })
+    }
+
+    before(() => {
+        cy.login()
+        createSite(site, { languages: 'en', templateSet: 'templates-system', serverName: 'localhost', locale: 'en' })
+
+        createUser(serverAdmin, 'password')
+        createUser(siteAdmin, 'password')
+        createUser(lowPriv, 'password')
+
+        grantRoles('/', ['server-administrator'], serverAdmin, 'USER')
+        grantRoles(`/sites/${site}`, ['site-administrator'], siteAdmin, 'USER')
+        grantRoles(`/sites/${site}`, ['editor'], lowPriv, 'USER')
+
+        // the server administrator must also be able to read the hosting site, so the positive control
+        // measures the screen and not the site's read ACL
+        grantRoles(`/sites/${site}`, ['editor'], serverAdmin, 'USER')
+
+        addNode({ parentPathOrId: `/sites/${site}/home`, primaryNodeType: 'jnt:contentList', name: 'pagecontent' })
+        screens.forEach((screen) => {
+            addNode({ parentPathOrId: area, primaryNodeType: screen.nodeType, name: placedName(screen) })
+        })
+    })
+
+    after(() => {
+        cy.login()
+        deleteUser(serverAdmin)
+        deleteUser(siteAdmin)
+        deleteUser(lowPriv)
+        deleteSite(site)
+    })
+
+    screens.forEach((screen) => {
+        describe(`the ${screen.label} screen`, () => {
+            it('is served to a server administrator (positive control)', () => {
+                fragment(serverAdmin, screen).then((body) => {
+                    expect(body, 'the server administrator must still be served the screen').to.contain(screen.marker)
+                })
+            })
+
+            it('is not served to an administrator of the hosting site only', () => {
+                fragment(siteAdmin, screen).then((body) => {
+                    expect(body.trim(), 'a site administrator must not be served a server settings screen').to.eq('')
+                })
+            })
+
+            it('is not served to a caller that administers nothing', () => {
+                fragment(lowPriv, screen).then((body) => {
+                    expect(body.trim(), 'no screen may be served to a caller that administers nothing').to.eq('')
+                })
+            })
+        })
+    })
+})


### PR DESCRIPTION
## Summary

Two server settings screens state their permission requirement only on the `jnt:contentTemplate` that normally hosts them. This states it on the screens themselves, so it holds on every render path rather than only on the one that goes through that template.

## Change

A `requirePermissions` view property next to each screen's default view, carrying the permission that screen's own template already declares in `repository.xml`:

- `jnt_serverSettingsSystemInfos` — `adminSystemInfos`
- `jnt_serverSettingsAboutJahia` — `administrationAccess`

Core's `TemplatePermissionCheckFilter` enforces it before the view runs, and it reaches every view variant through the default view's properties, so the `settingsBootstrap3GoogleMaterialStyle` variants need no file of their own.

Both permissions are registered by this module as children of the core `admin` permission, which the `server-administrator` role holds at the repository root. That is what makes this mechanism usable here: the property is evaluated against the node being rendered, so a root-granted permission resolves wherever the screen can render. A site-scoped permission would not, since it is held on a site while the screen's own node lives under `/modules`.

## Verification

`tests/cypress/e2e/settingsScreenRenderScope.cy.ts` covers both screens. Each is placed in an ordinary page area and requested as its own resource: served to a server administrator, empty for an administrator of the hosting site, empty for an account that administers nothing.

On a local 8.2.4.0-SNAPSHOT, an instance of each screen created in an ordinary page area, published, then rendered:

| screen | rendered |
|---|---|
| `jnt:serverSettingsSystemInfos`, anonymous | empty |
| `jnt:serverSettingsAboutJahia`, anonymous | empty |
| `jnt:serverSettingsSystemInfos`, `root` | 71 423 bytes |

The administration route is unchanged: `/cms/editframe/default/en/settings.systemInfos.html` still returns the screen for `root`.
