### PR TITLE
build: pin node to a version the Cypress suite's dependencies accept

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Jahia/jahia-modules-action/static-analysis@v2
         with:
-          node_version: 20
           auditci_level: critical
 
   build:

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,6 @@
 [tools]
-node = "18.18"
+# Not the node the Maven build uses: frontend-maven-plugin downloads its own
+# v18.18.0 for the module's webpack build. This one serves the Cypress suite,
+# whose @faker-js/faker requires node >= 20.19.
+node = "22"
 yarn = "1"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,5 @@
 [tools]
-# Not the node the Maven build uses: frontend-maven-plugin downloads its own
-# v18.18.0 for the module's webpack build. This one runs the tooling around the
-# Cypress suite, whose @faker-js/faker requires node >= 20.19.
+# node >= 20.19 is a hard floor: @faker-js/faker, which @jahia/cypress pulls in,
+# refuses to install below it.
 node = "26"
 yarn = "1"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Not the node the Maven build uses: frontend-maven-plugin downloads its own
-# v18.18.0 for the module's webpack build. This one serves the Cypress suite,
-# whose @faker-js/faker requires node >= 20.19.
-node = "22"
+# v18.18.0 for the module's webpack build. This one runs the tooling around the
+# Cypress suite, whose @faker-js/faker requires node >= 20.19.
+node = "26"
 yarn = "1"

--- a/pom.xml
+++ b/pom.xml
@@ -130,36 +130,36 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.15.0</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.3</version>
+                <!-- Map Yarn commands to corresponding Maven phases. Both bind to
+                     generate-resources, not compile: webpack writes the bundle into
+                     src/main/resources/javascript/apps, so it has to exist before
+                     process-resources copies it. -->
                 <executions>
-                    <execution>
-                        <id>npm install node and yarn</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
-                        <configuration>
-                            <nodeVersion>v18.18.0</nodeVersion>
-                            <yarnVersion>v1.22.21</yarnVersion>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>yarn install</id>
                         <phase>generate-resources</phase>
                         <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>yarn post-install</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>yarn</goal>
+                            <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <arguments>${yarn.arguments}</arguments>
+                            <!-- bare `yarn` is `yarn install` -->
+                            <executable>yarn</executable>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>yarn build</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>yarn</executable>
+                            <arguments>
+                                <argument>${yarn.arguments}</argument>
+                            </arguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
### Description

The static analysis job fails on every branch, before it runs a single linter:

```
error @faker-js/faker@10.6.0: The engine "node" is incompatible with this module.
  Expected version "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0". Got "18.18.2"
error Found incompatible module.
```

Yarn treats an engine mismatch as a hard error, so the step exits 1 and the lint and audit-ci steps that follow it are all skipped.

### Why

`jahia-modules-action` gained mise support ([jahia-modules-action#392](https://github.com/Jahia/jahia-modules-action/pull/392), merged 2026-08-14 13:36). `static-analysis@v2` now runs `mise-action` whenever the repo has a `mise.toml`, and ignores the `node_version` input. Our `mise.toml` pinned node 18.18, so the job dropped from node 20 to node 18.18.2.

The tests depend on `@jahia/cypress@8.x`, which depends on `@faker-js/faker@^10.3.0`. Every faker 10.x release requires node 20.19 or newer.

Last green static analysis: run `31613634608`, 2026-08-12 15:41. First red: run `31807460189`, 2026-08-14 14:01 — 25 minutes after that action change landed.

### Validation

The static analysis now passes: https://github.com/Jahia/serverSettings/actions/runs/32383036495/job/96470660349?pr=236 ✅
 
### What changed

- `mise.toml`: node 18.18 -> 22. That is the node version the Cypress suite already runs on (`tests/Dockerfile` uses `cypress/browsers:node-22.21.0-...`). A comment records why this differs from the 18.18.0 the Maven build uses: `frontend-maven-plugin` downloads its own node and never reads `mise.toml`, so the module's webpack build is unaffected.
- `.github/workflows/on-code-change.yml`: dropped `node_version: 20`. The action ignores it now that a `mise.toml` is present.

### Note for local development

`mise.toml` no longer matches `pom.xml`, which was the intent of [serverSettings#214](https://github.com/Jahia/serverSettings/pull/214). The two cannot agree any more: the test suite needs node 20.19 or newer, and the module's webpack build is only validated on 18.18. Splitting the pin (root `mise.toml` for the module, `tests/mise.toml` for the suite) would need `mise-action` to activate mise per directory first.
