### PR TITLE
test(site): open the create-web-project wizard once the screen's scripts have run

### DIFF
--- a/tests/cypress/e2e/page-object/ProjectsPage.ts
+++ b/tests/cypress/e2e/page-object/ProjectsPage.ts
@@ -27,7 +27,21 @@ export class ProjectsPage extends BasePage {
         return new ImportPage()
     }
 
+    /**
+     * Opens the create-web-project wizard.
+     *
+     * The button is an anchor, and the submit behind it runs from the `a.sitesAction` handler the screen
+     * binds in a document-ready callback. A click landing before that callback has run is a **lost
+     * one-shot event**: the retry that follows re-queries the DOM but never re-fires the click, so the
+     * wizard can never open however long the wait.
+     *
+     * The screen calls `dataTablesSettings.init` on the sites table from a *second* ready callback, and
+     * jQuery runs them in registration order — so the wrapper DataTables puts around the table is proof
+     * that the click already has a handler to run. Waiting on it also fails in the right direction: a
+     * screen whose scripts never run at all times out here instead of taking a click into the void.
+     */
     createSite() {
+        webProjectsFrame().find('#sitesTable_wrapper', { timeout: 30000 }).should('exist')
         webProjectsFrame().find('#createSite').click()
         return new CreateSitePage()
     }


### PR DESCRIPTION
## Summary

`siteCreation.cy.ts`, `siteExportImport.cy.ts` and `siteServerNameConflict.cy.ts` fail intermittently in the nightly run, all on the same assertion — `Expected to find element: #createSiteForm` timing out after 30 s in `CreateSitePage.fillDetails`. `ProjectsPage.createSite()` now waits for the screen's scripts to have run before it clicks.

## Why

The CREATE button is an `<a href="#create">`, and the submit behind it runs from the `a.sitesAction` handler that `serverSettingsManageWebProjects`' view binds in a document-ready callback. A click landing before that callback has run does nothing at all, and it is a one-shot event: Cypress retry-ability covers queries and assertions, not actions, so the 30 s wait that follows re-queries the DOM but never re-fires the click. The wizard can then never open, however long the wait. Nothing in the DOM expresses "this element has a listener", so no `should()` on the button can stand in for it.

What can stand in for it is ordering. The view binds the handler in its first document-ready callback and calls `dataTablesSettings.init` on the sites table in its second, and jQuery runs ready callbacks in registration order — so the wrapper DataTables puts around `#sitesTable` existing is proof the click already has a handler to run. Waiting on that is deterministic rather than best-effort, and it fails in the useful direction: a screen whose scripts never run at all times out on the wrapper instead of taking a click into the void.

Two facts from the nightly artifact say the click's POST never left the browser:

- `results/jahia.log` records exactly **one** render of `settings.webProjectSettings.html` per failing test — the initial page load — then nothing for the whole 30 s. In the same run, the wizard pass inside `siteExportImport` produced a burst of renders, one per wizard step. A refused or failing submit would still have been a request; there was none.
- The failure screenshots show the projects list intact, CREATE button and all, with no error and DataTables fully initialised by the time the screenshot was taken.

The later wizard steps need no equivalent change: each `_eventId_next` is a native `type="submit"` button inside its step's own form, so no script has to have run for it to post. That matches the failures, which are always at the first step and never at a later one.

## Verification

`yarn lint` and `npx prettier --check` are clean. The three specs run on this PR; the useful signal is the nightly, since a single green run has never been the question here — the failing set oscillated across ten consecutive nightlies on unchanged code ([Aug 12](https://github.com/Jahia/serverSettings/actions/runs/31561153804), [Aug 14](https://github.com/Jahia/serverSettings/actions/runs/31767859899), [Aug 17](https://github.com/Jahia/serverSettings/actions/runs/31990952041), [Aug 19](https://github.com/Jahia/serverSettings/actions/runs/32211824995), [Aug 20](https://github.com/Jahia/serverSettings/actions/runs/32327891737), [Aug 21](https://github.com/Jahia/serverSettings/actions/runs/32443235514), against green runs on the same sha on Aug 13, 15, 16 and 18).
